### PR TITLE
Double-protect Database dbReadLogs with a mutex, in case config.saveD…

### DIFF
--- a/src/prover/input.cpp
+++ b/src/prover/input.cpp
@@ -18,7 +18,7 @@ void Input::save (json &input) const
     saveDatabase     (input);
 }
 
-void Input::save (json &input, const Database &database) const
+void Input::save (json &input, Database &database) const
 {
     saveGlobals      (input);
     saveDatabase     (input, database);
@@ -309,8 +309,10 @@ void Input::saveDatabase (json &input) const
     contractsBytecode2json(input, contractsBytecode, "contractsBytecode");
 }
 
-void Input::saveDatabase (json &input, const Database &database) const
+void Input::saveDatabase (json &input, Database &database) const
 {
+    database.lock();
     db2json(input, database.dbReadLog, "db");
+    database.unlock();
     contractsBytecode2json(input, contractsBytecode, "contractsBytecode");    
 }

--- a/src/prover/input.hpp
+++ b/src/prover/input.hpp
@@ -35,7 +35,7 @@ public:
 
     // Saves the input object data into a JSON object
     void save (json &input) const;
-    void save (json &input, const Database &database) const;
+    void save (json &input, Database &database) const;
 
 private:
     void loadGlobals      (json &input);
@@ -47,7 +47,7 @@ public:
     map< string, vector<uint8_t> > contractsBytecode;
     void loadDatabase     (json &input);
     void saveDatabase     (json &input) const;
-    void saveDatabase     (json &input, const Database &database) const;
+    void saveDatabase     (json &input, Database &database) const;
     void preprocessTxs    (void);
 };
 

--- a/src/statedb/database.cpp
+++ b/src/statedb/database.cpp
@@ -52,7 +52,9 @@ zkresult Database::read (const string &_key, vector<Goldilocks::Element> &value)
         // Add to the read log
         if (config.saveDbReadsToFile)
         {
+            lock();
             dbReadLog[key] = value;
+            unlock();
         }
 
         r = ZKR_SUCCESS;
@@ -69,7 +71,9 @@ zkresult Database::read (const string &_key, vector<Goldilocks::Element> &value)
             // Add to the read log
             if (config.saveDbReadsToFile)
             {
+                lock();
                 dbReadLog[key] = value;
+                unlock();
             }
         }
     }
@@ -435,7 +439,9 @@ void Database::clearDbReadLog ()
         cerr << "Error: Database::clearDbReadLog() called with config.saveDbReadsToFile=false" << endl;
         exitProcess();
     }
+    lock();
     dbReadLog.clear();
+    unlock();
 }
 
 void Database::setAutoCommit (const bool ac)

--- a/src/statedb/database.hpp
+++ b/src/statedb/database.hpp
@@ -36,6 +36,11 @@ private:
 
 public:
     map<string, vector<Goldilocks::Element>> dbReadLog; // Log data read from the database
+private:
+    pthread_mutex_t mutex;    // Mutex to protect the dbReadLog access
+public:
+    void lock(void) { pthread_mutex_lock(&mutex); };
+    void unlock(void) { pthread_mutex_unlock(&mutex); };
 
 private:
     // Remote database based on Postgres (PostgreSQL)
@@ -46,7 +51,10 @@ private:
     void signalEmptyWriteQueue () {  };
 
 public:
-    Database(Goldilocks &fr) : fr(fr) {};
+    Database(Goldilocks &fr) : fr(fr)
+    {
+        pthread_mutex_init(&mutex, NULL);
+    };
     ~Database();
     void init (const Config &config);
     zkresult read (const string &key, vector<Goldilocks::Element> &value);


### PR DESCRIPTION
…bReadsToFile=true and we have multithread clients.