### PR TITLE
Added implementation of the buildconsttree function in C++

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -8,7 +8,7 @@
             "defines": [],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "gnu17",
-            "cppStandard": "gnu++14",
+            "cppStandard": "gnu++17",
             "intelliSenseMode": "linux-gcc-x64",
             "configurationProvider": "ms-vscode.makefile-tools"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "gcc - Build and debug active file",
+            "name": "zkProver",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/zkProver",
@@ -71,6 +71,34 @@
                 }
             ],
             "preLaunchTask": "C/C++: gcc build",
+            "miDebuggerPath": "/usr/bin/gdb"
+        },
+        {
+            "name": "bctree",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bctree",
+            "args": [
+                "-c",
+                "../testvectors/output/n21/zkevm.c12b.const",
+                "-s",
+                "../testvectors/output/n21/zkevm.c12b.starkstruct.json",
+                "-t",
+                "../testvectors/output/n21/zkevm.c12b.new.consttree"
+            ],            
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/testvectors",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "Build bctree",
             "miDebuggerPath": "/usr/bin/gdb"
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -80,11 +80,13 @@
             "program": "${workspaceFolder}/build/bctree",
             "args": [
                 "-c",
-                "../testvectors/output/n21/zkevm.c12b.const",
+                "../testvectors/zkevm.const",
                 "-s",
-                "../testvectors/output/n21/zkevm.c12b.starkstruct.json",
+                "../testvectors/zkevm.starkstruct.json",
                 "-t",
-                "../testvectors/output/n21/zkevm.c12b.new.consttree"
+                "../testvectors/output/zkevm.consttree",
+                "-k",
+                "../testvectors/output/zkevm.verkey.json"
             ],            
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/testvectors",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,9 +85,9 @@
                 "../testvectors/zkevm.starkstruct.json",
                 "-t",
                 "../testvectors/output/zkevm.consttree",
-                "-k",
+                "-v",
                 "../testvectors/output/zkevm.verkey.json"
-            ],            
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/testvectors",
             "environment": [],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"type": "cppbuild",
-			"label": "C/C++: gcc build",
+			"label": "Build zkProver",
 			"command": "make",
 			"args": [
 				"dbg=1",
@@ -18,6 +18,27 @@
 			"group": {
 				"kind": "build",
 				"isDefault": true
+			},
+			"detail": "compiler: /usr/bin/gcc"
+		},
+		{
+			"type": "cppbuild",
+			"label": "Build bctree",
+			"command": "make",
+			"args": [
+				"bctree",
+				"dbg=1",
+				"-j$(nproc)"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}"
+			},
+			"problemMatcher": [
+				"$gcc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
 			},
 			"detail": "compiler: /usr/bin/gcc"
 		}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-TARGET_EXEC := zkProver
+TARGET_ZKP := zkProver
+TARGET_BCT := bctree
 
 BUILD_DIR := ./build
 SRC_DIRS := ./src ./test ./tools
@@ -22,17 +23,22 @@ else
       CXXFLAGS += -O3
 endif
 
-SRCS := $(shell find $(SRC_DIRS) ! -path "./src/goldilocks/benchs/*" ! -path "./src/goldilocks/tests/*" -name *.cpp -or -name *.c -or -name *.asm -or -name *.cc)
-OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
-DEPS := $(OBJS:.o=.d)
-
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP
 
+all: $(BUILD_DIR)/$(TARGET_ZKP)
+SRCS := $(shell find $(SRC_DIRS) ! -path "./tools/starkpil/bctree/main.cpp" ! -path "./src/goldilocks/benchs/*" ! -path "./src/goldilocks/benchs/*" ! -path "./src/goldilocks/tests/*" -name *.cpp -or -name *.c -or -name *.asm -or -name *.cc)
+OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
+DEPS := $(OBJS:.o=.d)
 
-$(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)
+bctree: $(BUILD_DIR)/$(TARGET_BCT)
+SRCS := $(shell find $(SRC_DIRS) ! -path "./src/main.cpp" ! -path "./src/goldilocks/benchs/*" ! -path "./src/goldilocks/tests/*" -name *.cpp -or -name *.c -or -name *.asm -or -name *.cc)
+OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
+DEPS := $(OBJS:.o=.d)
+
+$(BUILD_DIR)/$(TARGET_ZKP) $(BUILD_DIR)/$(TARGET_BCT): $(OBJS)
 	$(CXX) $(OBJS) $(CXXFLAGS) -o $@ $(LDFLAGS)
 
 # assembly

--- a/tools/starkpil/bctree/build_const_tree.cpp
+++ b/tools/starkpil/bctree/build_const_tree.cpp
@@ -1,0 +1,392 @@
+#include "build_const_tree.hpp"
+#include <string>
+#include <nlohmann/json.hpp>
+#include "utils.hpp"
+#include <algorithm> 
+#include "goldilocks_base_field.hpp"
+#include "merklehash_goldilocks.hpp"
+#include "poseidon_goldilocks.hpp"
+#include <fstream>
+#include "timer.hpp"
+#include "merkleTreeBN128.hpp"
+#include <filesystem>
+#include <cstdint>
+
+using namespace std;
+using json = nlohmann::json;
+
+#define blocksPerThread 8
+#define maxBlockBits 16
+#define minBlockBits 12
+#define maxNperThread 1 << 18
+
+#define SIZE_GL 8
+
+Goldilocks fr;
+
+string time() 
+{
+    struct timeval t;
+    gettimeofday(&t, NULL);
+    return DateAndTime(t);
+}
+
+void writeToTextFile (std::string const & filename, uint64_t* data, uint64_t length)
+{
+    ofstream fw(filename, std::ofstream::out);
+    for (uint64_t i=0; i<length; i++)
+        fw << i << ": " << data[i] << endl;
+    fw.close();
+}
+
+void _fft_block (Goldilocks::Element* buff, uint64_t rel_pos, uint64_t start_pos, uint64_t nPols, uint64_t nBits, uint64_t s, uint64_t blockBits, uint64_t layers) {
+    uint64_t n = 1 << nBits;
+    uint64_t m = 1 << blockBits;
+    uint64_t md2 = m >> 1;
+
+    if (layers < blockBits) {
+        _fft_block(buff, rel_pos, start_pos, nPols, nBits, s, blockBits-1, layers);
+        _fft_block(buff, rel_pos, start_pos + md2, nPols, nBits, s, blockBits-1, layers);
+        return;
+    }
+    if (layers > 1) {
+        _fft_block(buff, rel_pos, start_pos, nPols, nBits, s-1, blockBits-1, layers-1);
+        _fft_block(buff, rel_pos, start_pos + md2, nPols, nBits, s-1, blockBits-1, layers-1);
+    }
+
+    Goldilocks::Element w;
+    if (s>blockBits) {
+        uint64_t width = 1 << (s-layers);
+        uint64_t heigth = n / width;
+        uint64_t y = floor(start_pos / heigth);
+        uint64_t x = start_pos % heigth;
+        uint64_t p = x*width + y;
+        w = fr.exp(fr.w(s), p);
+    } else {
+        w = fr.one();
+    }
+
+    for (uint64_t i=0; i<md2; i++) {
+        for (uint64_t j=0; j<nPols; j++) {
+            Goldilocks::Element t = fr.mul(w, buff[(start_pos - rel_pos + md2 + i)*nPols+j]);
+            Goldilocks::Element u = buff[(start_pos - rel_pos+i)*nPols+j];
+            buff[(start_pos - rel_pos+i)*nPols+j] = fr.add(u, t);
+            buff[(start_pos - rel_pos+md2+ i)*nPols+j] = fr.sub(u, t);
+        }
+        w = fr.mul(w, fr.w(layers));
+    }
+}
+
+Goldilocks::Element* fft_block (Goldilocks::Element* buff, uint64_t start_pos, uint64_t nPols, uint64_t nBits, uint64_t s, uint64_t blockBits, uint64_t layers) {
+    //cout << "start block " << s << " " << start_pos << endl;
+    _fft_block(buff, start_pos, start_pos, nPols, nBits, s, blockBits, layers);
+    //cout << "end block " << s << " " << start_pos << endl;
+    return buff;    
+}
+
+static inline u_int64_t BR (u_int64_t x, u_int64_t domainPow)
+{
+    x = (x >> 16) | (x << 16);
+    x = ((x & 0xFF00FF00) >> 8) | ((x & 0x00FF00FF) << 8);
+    x = ((x & 0xF0F0F0F0) >> 4) | ((x & 0x0F0F0F0F) << 4);
+    x = ((x & 0xCCCCCCCC) >> 2) | ((x & 0x33333333) << 2);
+    return (((x & 0xAAAAAAAA) >> 1) | ((x & 0x55555555) << 1)) >> (32-domainPow);
+}
+
+void bitReverse (Goldilocks::Element* buffDst, Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits) {
+    uint64_t n = 1 << nBits;
+    for (uint64_t i=0; i<n; i++) {
+        uint64_t ri = BR(i, nBits);
+        memcpy (buffDst + (i*nPols), buffSrc + (ri*nPols), nPols*SIZE_GL);
+    }
+}
+
+void interpolateBitReverse (Goldilocks::Element* buffDst, Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits) {
+    uint64_t n = 1 << nBits;
+    for (uint64_t i=0; i<n; i++) {
+        uint64_t ri = BR(i, nBits);
+        uint64_t rii = (n-ri)%n;
+        memcpy (buffDst + (i*nPols), buffSrc + (rii*nPols), nPols*SIZE_GL);
+    }
+}
+
+void traspose (Goldilocks::Element* buffDst, Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, uint64_t trasposeBits) {
+    uint64_t n = 1 << nBits;
+    uint64_t w = 1 << trasposeBits;
+    uint64_t h = n/w;
+    for (uint64_t i=0; i<w; i++) {
+        for (uint64_t j=0; j<h; j++) {
+            uint64_t fi = j*w + i;
+            uint64_t di = i*h +j;
+            memcpy (buffDst + (di*nPols), buffSrc + (fi*nPols), nPols*SIZE_GL);
+        }
+    }
+}
+
+Goldilocks::Element* interpolatePrepareBlock (Goldilocks::Element* buff, uint64_t bufflen, uint64_t width, Goldilocks::Element start, Goldilocks::Element inc, uint64_t st_i, uint64_t st_n) {
+    //cout << time() << " linear interpolatePrepare start.... " << st_i << "/" << st_n << endl;
+
+    uint64_t heigth = bufflen/width;
+    Goldilocks::Element w = start;
+    for (uint64_t i = 0; i<heigth; i++) {
+        for (uint64_t j=0; j<width; j++) {
+            buff[i*width+j] = fr.mul(buff[i*width+j], w);
+        }
+        w = fr.mul(w, inc);
+    }
+    //cout << time() << " linear interpolatePrepare end.... " << st_i << "/" << st_n << endl;
+    return buff;    
+}
+
+void interpolatePrepare (Goldilocks::Element* buff, uint64_t nPols, uint64_t nBits, uint64_t nBitsExt ) {
+    uint64_t n = 1 << nBits;
+    Goldilocks::Element invN = fr.inv(fr.fromU64(n));
+
+    uint64_t maxNPerThread = 1 << 18;
+    uint64_t minNPerThread = 1 << 12;
+
+    int numThreads = omp_get_max_threads()/2;
+    uint64_t nPerThreadF = floor((n-1)/numThreads)+1;
+
+    uint64_t maxCorrected = floor(maxNPerThread / nPols);
+    uint64_t minCorrected = floor(minNPerThread / nPols);
+
+    if (nPerThreadF>maxCorrected) nPerThreadF = maxCorrected;
+    if (nPerThreadF<minCorrected) nPerThreadF = minCorrected;
+
+#pragma omp parallel for
+    for (uint64_t i=0; i< n; i+=nPerThreadF) {
+        uint64_t curN = min(nPerThreadF, n-i);
+
+        Goldilocks::Element* bb = (Goldilocks::Element*) malloc (curN*nPols*SIZE_GL);
+        memcpy (bb, buff+(i*nPols), curN*nPols*SIZE_GL);
+
+        Goldilocks::Element start = fr.mul(invN, fr.exp(fr.shift(), i));
+        Goldilocks::Element inc = fr.shift();
+        Goldilocks::Element* res = interpolatePrepareBlock(bb, curN*nPols, nPols, start, inc, i/nPerThreadF, floor(n/nPerThreadF));
+        memcpy (buff+(i*nPols), res, curN*nPols*SIZE_GL);
+
+        free (bb);
+    }
+
+    //writeToTextFile ("interpolatePrepare.new.txt", buff, (1 << nBitsExt)*nPols);
+}
+
+void interpolate (Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, Goldilocks::Element* buffDst, uint64_t nBitsExt) 
+{
+    uint64_t n = 1 << nBits;
+    uint64_t nExt = 1 << nBitsExt;
+    Goldilocks::Element* tmpBuff = (Goldilocks::Element*) malloc(nExt*nPols*SIZE_GL);
+    Goldilocks::Element* outBuff = buffDst;
+
+    Goldilocks::Element* bIn;
+    Goldilocks::Element* bOut;
+
+    int numThreads = omp_get_max_threads()/2;
+    uint64_t idealNBlocks = numThreads*blocksPerThread;
+    uint64_t nTrasposes = 0;
+
+    uint64_t blockBits = (uint64_t) log2(n*nPols/idealNBlocks);
+    if (blockBits < minBlockBits) blockBits = minBlockBits;
+    if (blockBits > maxBlockBits) blockBits = maxBlockBits;
+    blockBits = min(nBits, blockBits);
+    uint64_t blockSize = 1 << blockBits;
+    uint64_t nBlocks = n /blockSize;
+
+    if (blockBits < nBits) {
+        nTrasposes += floor((nBits-1) / blockBits)+1;
+    }
+
+    nTrasposes += 1; // The middle convertion    
+
+    uint64_t blockBitsExt = (uint64_t) log2(nExt*nPols/idealNBlocks);
+    if (blockBitsExt < minBlockBits) blockBitsExt = minBlockBits;
+    if (blockBitsExt > maxBlockBits) blockBitsExt = maxBlockBits;
+    blockBitsExt = min(nBitsExt, blockBitsExt);
+    uint64_t blockSizeExt = 1 << blockBitsExt;
+    uint64_t nBlocksExt = nExt / blockSizeExt;    
+
+    if (blockBitsExt < nBitsExt) {
+        nTrasposes += floor((nBitsExt-1) / blockBitsExt)+1;
+    }   
+
+    if (nTrasposes & 1) {
+        bOut = tmpBuff;
+        bIn = outBuff;
+    } else {
+        bOut = outBuff;
+        bIn = tmpBuff;
+    }     
+
+    cout << time() << " Interpolating bit reverse" << endl;
+    interpolateBitReverse(bOut, buffSrc, nPols, nBits);
+
+//    writeToTextFile ("interpolateBitReverse.new.txt", bOut, (1 << nBitsExt)*nPols);
+
+    Goldilocks::Element* bTmp;
+    bTmp = bIn;
+    bIn = bOut;
+    bOut = bTmp;
+
+    for (uint64_t i=0; i<nBits; i+= blockBits) {
+        cout << time() << " Layer ifft " << i << endl;
+        uint64_t sInc = min(blockBits, nBits-i);
+
+#pragma omp parallel for
+        for (uint64_t j=0; j<nBlocks; j++) {
+            Goldilocks::Element* bb = (Goldilocks::Element*) malloc (blockSize*nPols*SIZE_GL);
+            memcpy (bb, bIn+(j*blockSize*nPols), blockSize*nPols*SIZE_GL);
+
+            Goldilocks::Element* res = fft_block(bb, j*blockSize, nPols, nBits, i+sInc, blockBits, sInc);
+            memcpy (bIn+(j*blockSize*nPols), res, blockSize*nPols*SIZE_GL);
+
+            free(bb);
+        }
+
+        if (sInc < nBits) {                // Do not transpose if it's the same
+            traspose (bOut, bIn, nPols, nBits, sInc);
+            bTmp = bIn;
+            bIn = bOut;
+            bOut = bTmp;
+        }
+    }
+
+    //writeToTextFile("bIn.new.txt", bIn, (1 << nBitsExt));
+    //writeToTextFile("bOut.new.txt", bOut, (1 << nBitsExt));
+
+    cout << time() << " Interpolating prepare" << endl;
+    interpolatePrepare(bIn, nPols, nBits, nBitsExt);
+    cout << time() << " Bit reverse" << endl;
+    bitReverse(bOut, bIn, nPols, nBitsExt);
+    
+    //writeToTextFile("bitReverse.bIn.new.txt", bIn, (1 << nBitsExt));
+    //writeToTextFile("bitReverse.bOut.new.txt", bOut, (1 << nBitsExt));
+
+    bTmp = bIn;
+    bIn = bOut;
+    bOut = bTmp;
+
+    for (uint64_t i=0; i<nBitsExt; i+= blockBitsExt) {
+        cout << time() << " Layer fft " << i << endl;
+        uint64_t sInc = min(blockBitsExt, nBitsExt-i);
+
+#pragma omp parallel for
+        for (uint64_t j=0; j<nBlocksExt; j++) {
+            Goldilocks::Element* bb = (Goldilocks::Element*) malloc (blockSizeExt*nPols*SIZE_GL);
+            memcpy (bb, bIn+(j*blockSizeExt*nPols), blockSizeExt*nPols*SIZE_GL);
+
+            Goldilocks::Element* res = fft_block(bb, j*blockSizeExt, nPols, nBitsExt, i+sInc, blockBitsExt, sInc);
+            memcpy (bIn+(j*blockSizeExt*nPols), res, blockSizeExt*nPols*SIZE_GL);
+
+            free(bb);
+        }
+
+        if (sInc < nBitsExt) {                // Do not transpose if it's the same
+            traspose(bOut, bIn, nPols, nBitsExt, sInc);
+            bTmp = bIn;
+            bIn = bOut;
+            bOut = bTmp;
+        }
+    }
+
+    free(tmpBuff);
+}
+
+void buildConstTree(const string constFile, const string starkStructFile, const string constTreeFile, const string verKeyFile)
+{
+    TimerStart(BUILD_CONST_TREE);
+
+    json starkStruct;
+    file2json(starkStructFile, starkStruct);   
+
+    uint64_t nBits = starkStruct["nBits"];
+    uint64_t nBitsExt = starkStruct["nBitsExt"];
+    uint64_t n = 1 << nBits;
+    uint64_t nExt = 1 << nBitsExt;
+
+    uintmax_t constFileSize = filesystem::file_size(constFile);
+    uint64_t nPols = constFileSize/(n*SIZE_GL);
+
+    cout << time() << " Pols=" << nPols << endl;
+    cout << time() << " nBits=" << nBits << endl;
+    cout << time() << " nBitsExt=" << nBitsExt << endl;
+
+    cout << time() << " Loading const file " << constFile << endl;
+    Goldilocks::Element* pConstPols = (Goldilocks::Element*) copyFile(constFile, constFileSize);
+    Goldilocks::Element* constPolsArrayE = (Goldilocks::Element*) malloc(nExt*nPols*SIZE_GL);
+
+    TimerStart(Interpolate);
+    interpolate(pConstPols, nPols, nBits, constPolsArrayE, nBitsExt );
+    TimerStopAndLog(Interpolate);
+
+    //writeToTextFile ("../build/tmp/constPolsArrayE.new.txt", constPolsArrayE, nExt*nPols);
+
+    if (starkStruct["verificationHashType"] == "GL") {
+
+        TimerStart(MerkleTree_GL);
+        uint64_t numElementsTree = MerklehashGoldilocks::getTreeNumElements(nPols, nExt);
+        uint64_t sizeConstTree = numElementsTree*sizeof(Goldilocks::Element);
+        Goldilocks::Element* constTree = (Goldilocks::Element *)malloc(numElementsTree*SIZE_GL);        
+        PoseidonGoldilocks::merkletree(constTree, constPolsArrayE, nPols, nExt);
+        TimerStopAndLog(MerkleTree_GL);   
+    
+        cout << time() << " Generating files..." << endl;       
+
+        //VerKey
+        if (verKeyFile!="") {
+            json jsonVerKey;
+            json value;
+            value[0] = fr.toString(constTree[numElementsTree-4]);
+            value[1] = fr.toString(constTree[numElementsTree-3]);
+            value[2] = fr.toString(constTree[numElementsTree-2]);
+            value[3] = fr.toString(constTree[numElementsTree-1]);
+            jsonVerKey["constRoot"] = value;
+            json2file(jsonVerKey, verKeyFile);
+        }
+
+        //ConstTree
+        ofstream fw(constTreeFile.c_str(), std::fstream::out | std::fstream::binary);
+        fw.write((char const*) constTree, sizeConstTree);
+        fw.close();
+
+        cout << time() << " Files Generated Correctly" << endl; 
+
+        free (constTree);
+
+    } else if (starkStruct["verificationHashType"] == "BN128") {
+
+        TimerStart(MerkleTree_BN128);
+        MerkleTreeBN128 mt(nExt, nPols, constPolsArrayE);
+        TimerStopAndLog(MerkleTree_BN128);   
+
+        cout << time() << " Generating files..." << endl;       
+        
+        //VerKey
+        if (verKeyFile!="") {
+            RawFr::Element constRoot = mt.root();
+            RawFr rawfr;
+            json jsonVerKey;
+            json value;
+            value = rawfr.toString(constRoot);
+            jsonVerKey["constRoot"] = value;
+            json2file(jsonVerKey, verKeyFile);
+        }
+
+        //ConstTree
+        std::ofstream fw(constTreeFile.c_str(), std::fstream::out | std::fstream::binary);
+        fw.write((const char*) &(mt.source_width), sizeof(mt.source_width));
+        fw.write((const char*) &(mt.height), sizeof(mt.height));
+        fw.write((const char*) mt.elements, nPols*nExt*SIZE_GL);
+        fw.write((const char*) mt.nodes, mt.numNodes*sizeof(RawFr::Element));
+        fw.close();
+
+        cout << time() << " Files Generated Correctly" << endl; 
+
+    } else {
+        cerr << "Invalid Hash Type: " << starkStruct["verificationHashType"] << endl;
+        exit(-1);
+    }
+
+    free(constPolsArrayE);
+    TimerStopAndLog(BUILD_CONST_TREE);
+}

--- a/tools/starkpil/bctree/build_const_tree.cpp
+++ b/tools/starkpil/bctree/build_const_tree.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <nlohmann/json.hpp>
 #include "utils.hpp"
-#include <algorithm> 
+#include <algorithm>
 #include "goldilocks_base_field.hpp"
 #include "merklehash_goldilocks.hpp"
 #include "poseidon_goldilocks.hpp"
@@ -24,7 +24,7 @@ using json = nlohmann::json;
 
 Goldilocks fr;
 
-string time() 
+string time()
 {
     struct timeval t;
     gettimeofday(&t, NULL);
@@ -81,7 +81,7 @@ Goldilocks::Element* fft_block (Goldilocks::Element* buff, uint64_t start_pos, u
     //cout << "start block " << s << " " << start_pos << endl;
     _fft_block(buff, start_pos, start_pos, nPols, nBits, s, blockBits, layers);
     //cout << "end block " << s << " " << start_pos << endl;
-    return buff;    
+    return buff;
 }
 
 static inline u_int64_t BR (u_int64_t x, u_int64_t domainPow)
@@ -135,7 +135,7 @@ Goldilocks::Element* interpolatePrepareBlock (Goldilocks::Element* buff, uint64_
         w = fr.mul(w, inc);
     }
     //cout << time() << " linear interpolatePrepare end.... " << st_i << "/" << st_n << endl;
-    return buff;    
+    return buff;
 }
 
 void interpolatePrepare (Goldilocks::Element* buff, uint64_t nPols, uint64_t nBits, uint64_t nBitsExt ) {
@@ -172,7 +172,7 @@ void interpolatePrepare (Goldilocks::Element* buff, uint64_t nPols, uint64_t nBi
     //writeToTextFile ("interpolatePrepare.new.txt", buff, (1 << nBitsExt)*nPols);
 }
 
-void interpolate (Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, Goldilocks::Element* buffDst, uint64_t nBitsExt) 
+void interpolate (Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, Goldilocks::Element* buffDst, uint64_t nBitsExt)
 {
     uint64_t n = 1 << nBits;
     uint64_t nExt = 1 << nBitsExt;
@@ -197,18 +197,18 @@ void interpolate (Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, 
         nTrasposes += floor((nBits-1) / blockBits)+1;
     }
 
-    nTrasposes += 1; // The middle convertion    
+    nTrasposes += 1; // The middle convertion
 
     uint64_t blockBitsExt = (uint64_t) log2(nExt*nPols/idealNBlocks);
     if (blockBitsExt < minBlockBits) blockBitsExt = minBlockBits;
     if (blockBitsExt > maxBlockBits) blockBitsExt = maxBlockBits;
     blockBitsExt = min(nBitsExt, blockBitsExt);
     uint64_t blockSizeExt = 1 << blockBitsExt;
-    uint64_t nBlocksExt = nExt / blockSizeExt;    
+    uint64_t nBlocksExt = nExt / blockSizeExt;
 
     if (blockBitsExt < nBitsExt) {
         nTrasposes += floor((nBitsExt-1) / blockBitsExt)+1;
-    }   
+    }
 
     if (nTrasposes & 1) {
         bOut = tmpBuff;
@@ -216,7 +216,7 @@ void interpolate (Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, 
     } else {
         bOut = outBuff;
         bIn = tmpBuff;
-    }     
+    }
 
     cout << time() << " Interpolating bit reverse" << endl;
     interpolateBitReverse(bOut, buffSrc, nPols, nBits);
@@ -258,7 +258,7 @@ void interpolate (Goldilocks::Element* buffSrc, uint64_t nPols, uint64_t nBits, 
     interpolatePrepare(bIn, nPols, nBits, nBitsExt);
     cout << time() << " Bit reverse" << endl;
     bitReverse(bOut, bIn, nPols, nBitsExt);
-    
+
     //writeToTextFile("bitReverse.bIn.new.txt", bIn, (1 << nBitsExt));
     //writeToTextFile("bitReverse.bOut.new.txt", bOut, (1 << nBitsExt));
 
@@ -297,7 +297,7 @@ void buildConstTree(const string constFile, const string starkStructFile, const 
     TimerStart(BUILD_CONST_TREE);
 
     json starkStruct;
-    file2json(starkStructFile, starkStruct);   
+    file2json(starkStructFile, starkStruct);
 
     uint64_t nBits = starkStruct["nBits"];
     uint64_t nBitsExt = starkStruct["nBitsExt"];
@@ -326,20 +326,20 @@ void buildConstTree(const string constFile, const string starkStructFile, const 
         TimerStart(MerkleTree_GL);
         uint64_t numElementsTree = MerklehashGoldilocks::getTreeNumElements(nPols, nExt);
         uint64_t sizeConstTree = numElementsTree*sizeof(Goldilocks::Element);
-        Goldilocks::Element* constTree = (Goldilocks::Element *)malloc(numElementsTree*SIZE_GL);        
+        Goldilocks::Element* constTree = (Goldilocks::Element *)malloc(numElementsTree*SIZE_GL);
         PoseidonGoldilocks::merkletree(constTree, constPolsArrayE, nPols, nExt);
-        TimerStopAndLog(MerkleTree_GL);   
-    
-        cout << time() << " Generating files..." << endl;       
+        TimerStopAndLog(MerkleTree_GL);
+
+        cout << time() << " Generating files..." << endl;
 
         //VerKey
         if (verKeyFile!="") {
             json jsonVerKey;
             json value;
-            value[0] = fr.toString(constTree[numElementsTree-4]);
-            value[1] = fr.toString(constTree[numElementsTree-3]);
-            value[2] = fr.toString(constTree[numElementsTree-2]);
-            value[3] = fr.toString(constTree[numElementsTree-1]);
+            value[0] = fr.toU64(constTree[numElementsTree-4]);
+            value[1] = fr.toU64(constTree[numElementsTree-3]);
+            value[2] = fr.toU64(constTree[numElementsTree-2]);
+            value[3] = fr.toU64(constTree[numElementsTree-1]);
             jsonVerKey["constRoot"] = value;
             json2file(jsonVerKey, verKeyFile);
         }
@@ -349,7 +349,7 @@ void buildConstTree(const string constFile, const string starkStructFile, const 
         fw.write((char const*) constTree, sizeConstTree);
         fw.close();
 
-        cout << time() << " Files Generated Correctly" << endl; 
+        cout << time() << " Files Generated Correctly" << endl;
 
         free (constTree);
 
@@ -357,10 +357,10 @@ void buildConstTree(const string constFile, const string starkStructFile, const 
 
         TimerStart(MerkleTree_BN128);
         MerkleTreeBN128 mt(nExt, nPols, constPolsArrayE);
-        TimerStopAndLog(MerkleTree_BN128);   
+        TimerStopAndLog(MerkleTree_BN128);
 
-        cout << time() << " Generating files..." << endl;       
-        
+        cout << time() << " Generating files..." << endl;
+
         //VerKey
         if (verKeyFile!="") {
             RawFr::Element constRoot = mt.root();
@@ -380,7 +380,7 @@ void buildConstTree(const string constFile, const string starkStructFile, const 
         fw.write((const char*) mt.nodes, mt.numNodes*sizeof(RawFr::Element));
         fw.close();
 
-        cout << time() << " Files Generated Correctly" << endl; 
+        cout << time() << " Files Generated Correctly" << endl;
 
     } else {
         cerr << "Invalid Hash Type: " << starkStruct["verificationHashType"] << endl;

--- a/tools/starkpil/bctree/build_const_tree.hpp
+++ b/tools/starkpil/bctree/build_const_tree.hpp
@@ -1,0 +1,12 @@
+#ifndef BUILD_CONST_TREE_HPP
+#define BUILD_CONST_TREE_HPP
+
+#include <cstdint>
+#include <string>
+#include "goldilocks_base_field.hpp"
+
+using namespace std;
+
+void buildConstTree(const string constFile, const string starkStructFile, const string constTreeFile, const string verKeyFile);
+
+#endif

--- a/tools/starkpil/bctree/main.cpp
+++ b/tools/starkpil/bctree/main.cpp
@@ -1,0 +1,95 @@
+#include "build_const_tree.hpp"
+#include "utils.hpp"
+#include "timer.hpp"
+
+#define BCTREE_VERSION "0.1.0.0"
+
+using namespace std;
+
+class ArgumentParser {
+private:
+    vector <string> arguments;
+public:
+    ArgumentParser (int &argc, char **argv)
+    {
+        for (int i=1; i < argc; ++i)
+            arguments.push_back(string(argv[i]));
+    }
+
+    string getArgumentValue (const string argshort, const string arglong) 
+    {
+        for (size_t i=0; i<arguments.size(); i++) {
+            if (argshort==arguments[i] || arglong==arguments[i]) {
+                if (i+1 < arguments.size()) return (arguments[i+1]);
+                else return "";
+            }
+        }
+        return "";
+    }
+
+    bool argumentExists (const string argshort, const string arglong) 
+    {
+        bool found = false;
+        for (size_t i=0; i<arguments.size(); i++) {
+            if (argshort==arguments[i] || arglong==arguments[i]) {
+                if (found) {
+                    throw runtime_error("bctree: cannot use "+argshort+"/"+arglong+" parameter twice!");
+                } else found = true;
+            }
+        }
+        return found;
+    }
+};
+
+void showVersion() 
+{
+    cout << "bctree: version " << string(BCTREE_VERSION) << endl;
+}
+
+int main(int argc, char **argv)
+{
+    string constFile = "";
+    string starkStructFile = "";
+    string constTreeFile = "";
+    string verKeyFile = "";
+
+    ArgumentParser aParser (argc, argv);
+
+    try {
+        if (aParser.argumentExists("-v","--version")) {
+            showVersion();
+            return EXIT_SUCCESS;
+        }
+
+        //Input arguments
+        if (aParser.argumentExists("-c","--const")) {
+            constFile = aParser.getArgumentValue("-c", "--const");
+            if (!fileExists(constFile)) throw runtime_error("bctree: constants file doesn't exist ("+constFile+")");
+        } else throw runtime_error("bctree: constants input file argument not specified <-c/--const> <const_file>");
+        if (aParser.argumentExists("-s","--stark")) {
+            starkStructFile = aParser.getArgumentValue("-s", "--stark");
+            if (!fileExists(starkStructFile)) throw runtime_error("bctree: starkstruct file doesn't exist ("+starkStructFile+")");
+        } else throw runtime_error("bctree: starkstruct input file argument not specified <-s/--stark> <starkstruct_file>");
+
+        //Output arguments
+        if (aParser.argumentExists("-t","--tree")) {
+            constTreeFile = aParser.getArgumentValue("-t","--tree");
+            if (constTreeFile=="") throw runtime_error("bctree: constants tree output file not specified");
+        } else throw runtime_error("bctree: constants tree ouput file argument not specified <-t/--tree> <consttree_file>");
+        if (aParser.argumentExists("-k","--key")) {
+            verKeyFile = aParser.getArgumentValue("-k","--key");
+            if (verKeyFile=="") throw runtime_error("bctree: key ouput file not specified");
+        }
+
+        showVersion();
+
+        buildConstTree(constFile, starkStructFile, constTreeFile, verKeyFile);
+        
+        return EXIT_SUCCESS;
+    } catch (const exception &e) {
+        cerr << e.what() << endl;
+        cerr << "usage: bctree <-c|--const> <const_file> <-s|--stark> <starkstruct_file> <-t|--tree> <consttree_file> [-k|--key] [verkey_file]" << endl;
+        cerr << "example: bctree -c zkevm.const -s zkevm.starkstruct.json -t zkevm.consttree -k zkevm.verkey" << endl;
+        return EXIT_FAILURE;        
+    }    
+}

--- a/tools/starkpil/bctree/main.cpp
+++ b/tools/starkpil/bctree/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
         return EXIT_SUCCESS;
     } catch (const exception &e) {
         cerr << e.what() << endl;
-        cerr << "usage: bctree <-c|--const> <const_file> <-s|--stark> <starkstruct_file> <-t|--tree> <consttree_file> [-k|--key] [verkey_file]" << endl;
+        cerr << "usage: bctree <-c|--const> <const_file> <-s|--stark> <starkstruct_file> <-t|--tree> <consttree_file> [<-k|--key> <verkey_file>]" << endl;
         cerr << "example: bctree -c zkevm.const -s zkevm.starkstruct.json -t zkevm.consttree -k zkevm.verkey" << endl;
         return EXIT_FAILURE;        
     }    

--- a/tools/starkpil/bctree/main.cpp
+++ b/tools/starkpil/bctree/main.cpp
@@ -56,11 +56,6 @@ int main(int argc, char **argv)
     ArgumentParser aParser (argc, argv);
 
     try {
-        if (aParser.argumentExists("-v","--version")) {
-            showVersion();
-            return EXIT_SUCCESS;
-        }
-
         //Input arguments
         if (aParser.argumentExists("-c","--const")) {
             constFile = aParser.getArgumentValue("-c", "--const");
@@ -76,8 +71,8 @@ int main(int argc, char **argv)
             constTreeFile = aParser.getArgumentValue("-t","--tree");
             if (constTreeFile=="") throw runtime_error("bctree: constants tree output file not specified");
         } else throw runtime_error("bctree: constants tree ouput file argument not specified <-t/--tree> <consttree_file>");
-        if (aParser.argumentExists("-k","--key")) {
-            verKeyFile = aParser.getArgumentValue("-k","--key");
+        if (aParser.argumentExists("-v","--verkey")) {
+            verKeyFile = aParser.getArgumentValue("-v","--verkey");
             if (verKeyFile=="") throw runtime_error("bctree: key ouput file not specified");
         }
 
@@ -88,8 +83,9 @@ int main(int argc, char **argv)
         return EXIT_SUCCESS;
     } catch (const exception &e) {
         cerr << e.what() << endl;
-        cerr << "usage: bctree <-c|--const> <const_file> <-s|--stark> <starkstruct_file> <-t|--tree> <consttree_file> [<-k|--key> <verkey_file>]" << endl;
-        cerr << "example: bctree -c zkevm.const -s zkevm.starkstruct.json -t zkevm.consttree -k zkevm.verkey" << endl;
+        showVersion();
+        cerr << "usage: bctree <-c|--const> <const_file> <-s|--stark> <starkstruct_file> <-t|--tree> <consttree_file> [<-v|--verkey> <verkey_file>]" << endl;
+        cerr << "example: bctree -c zkevm.const -s zkevm.starkstruct.json -t zkevm.consttree -v zkevm.verkey" << endl;
         return EXIT_FAILURE;        
     }    
 }


### PR DESCRIPTION
Added implementation of the buildconsttree function (from pil-stark JS) in C++. The implementation is located in ./tools/starkpil/bctree

Modified the Makefile file to add 2 targets:
- target "all" builds the zkProver binary (this is the default option if you run "make -j"). This options doesn't build the bctree binary
- target "bctree" builds the bctree binary (you must run "make bctree -j")

Added a vscode task (task.json) to build the "bctree" binary. Also added a vscode launch option (launch.json) to run the bctree with some default params (you can change the params to test with different inputs or run it from the command line).

The default vscode task "C/C++: gcc build" has been renamed to "Build zkProver". Also the launch option "gcc - Build and debug active file" has been renamed to "zkProver"

Usage of the bctree tool:
usage: bctree <-c|--const> <const_file> <-s|--stark> <starkstruct_file> <-t|--tree> <consttree_file> [<-v|--verkey> <verkey_file>]
example: bctree -c zkevm.const -s zkevm.starkstruct.json -t zkevm.consttree -v zkevm.verkey

Some bctree performance metrics (compiled with O3):
Test server: 16 cores, 512GB RAM	
zkevm.consttree -> n21=58s, n23=240s
zkevm.c12.consttree -> n21=62s	
zkevm.c12a.consttree -> n23=98s

bonus: changed the "cppStandard" paramater of the "c_cpp_properties.json" vscode file to "gnu++17" (instead of "gnu++14") to avoid syntax warnings in the vscode