### PR TITLE
Executor client multithread improvements

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -37,6 +37,12 @@ void Config::load(json &config)
     {
         runExecutorClient = config["runExecutorClient"];
     }
+    runExecutorClientMultithread = false;
+    if (config.contains("runExecutorClientMultithread") &&
+        config["runExecutorClientMultithread"].is_boolean())
+    {
+        runExecutorClientMultithread = config["runExecutorClientMultithread"];
+    }
     runStateDBServer = false;
     if (config.contains("runStateDBServer") &&
         config["runStateDBServer"].is_boolean())
@@ -436,6 +442,8 @@ void Config::print(void)
         cout << "runExecutorServer=true" << endl;
     if (runExecutorClient)
         cout << "runExecutorClient=true" << endl;
+    if (runExecutorClientMultithread)
+        cout << "runExecutorClientMultithread=true" << endl;
     if (runStateDBServer)
         cout << "runStateDBServer=true" << endl;
     if (runStateDBTest)

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -17,6 +17,7 @@ public:
     bool runProverClient;
     bool runExecutorServer;
     bool runExecutorClient;
+    bool runExecutorClientMultithread;
     bool runStateDBServer;
     bool runStateDBTest;
     bool runFile;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
 
     // If there is nothing else to run, exit normally
     if (!config.runProverServer && !config.runProverServerMock && !config.runProverClient &&
-        !config.runExecutorServer && !config.runExecutorClient &&
+        !config.runExecutorServer && !config.runExecutorClient && !config.runExecutorClientMultithread &&
         !config.runFile && !config.runFileFast && !config.runFileFastMultithread && !config.runStateDBServer && !config.runStateDBTest)
     {
         exit(0);
@@ -408,6 +408,13 @@ int main(int argc, char **argv)
         executorClient.runThread();
     }
 
+    // Run the executor client multithread, if configured
+    if (config.runExecutorClientMultithread)
+    {
+        cout << "Launching executor client threads..." << endl;
+        executorClient.runThreads();
+    }
+
     // Run the stateDB test, if configured
     if (config.runStateDBTest)
     {
@@ -415,12 +422,21 @@ int main(int argc, char **argv)
         runStateDBTest(config);
     }
 
-    /* THREADS COMPETION */
+    /* WAIT FOR CLIENT THREADS COMPETION */
 
     // Wait for the executor client thread to end
     if (config.runExecutorClient)
     {
         executorClient.waitForThread();
+        sleep(1);
+        exit(0);
+    }
+
+    // Wait for the executor client thread to end
+    if (config.runExecutorClientMultithread)
+    {
+        executorClient.waitForThreads();
+        cout << "All executor client threads have completed" << endl;
         sleep(1);
         exit(0);
     }

--- a/src/service/executor/executor_service.cpp
+++ b/src/service/executor/executor_service.cpp
@@ -313,7 +313,16 @@ using grpc::Status;
     double execTime = double(TimeDiff(EXECUTOR_PROCESS_BATCH_start, EXECUTOR_PROCESS_BATCH_stop))/1000000;
     totalTime += execTime;
     counter++;
-    cout << "ExecutorServiceImpl::ProcessBatch() done counter=" << counter << " gas=" << execGas << " time=" << execTime << " TP=" << double(execGas)/execTime << " gas/s" << " totalGas=" << totalGas << " totalTime=" << totalTime << " totalTP=" << double(totalGas)/totalTime << " gas/s" << endl;
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    double timeSinceLastTotal = double(TimeDiff(lastTotalTime, now))/1000000;
+    if (timeSinceLastTotal >= 1.0)
+    {
+        totalTP = double(totalGas - lastTotalGas)/timeSinceLastTotal;
+        lastTotalGas = totalGas;
+        lastTotalTime = now;
+    }
+    cout << "ExecutorServiceImpl::ProcessBatch() done counter=" << counter << " gas=" << execGas << " time=" << execTime << " TP=" << double(execGas)/execTime << " gas/s" << " totalGas=" << totalGas << " totalTime=" << totalTime << " avgTP=" << double(totalGas)/totalTime << " gas/s totalTP=" << totalTP << " gas/s" << endl;
     unlock();
 #endif
 

--- a/src/service/executor/executor_service.hpp
+++ b/src/service/executor/executor_service.hpp
@@ -19,11 +19,16 @@ class ExecutorServiceImpl final : public executor::v1::ExecutorService::Service
     uint64_t counter; // Total number of calls to ProcessBatch
     uint64_t totalGas; // Total gas, i.e. the sum of gas of all calls to ProcessBatch
     double totalTime; // Total time, i.e. the sum of time (in seconds) of all calls to ProcessBatch
+    struct timeval lastTotalTime; // Time when the last total was calculated
+    uint64_t lastTotalGas; // Gas when the last total was calculated
+    double totalTP; // Total throughput, calculated when time since lastTotalTime > 1s
     pthread_mutex_t mutex; // Mutex to protect the access to the throughput attributes
 
 public:
-    ExecutorServiceImpl (Goldilocks &fr, Config &config, Prover &prover) : fr(fr), config(config), prover(prover), counter(0), totalGas(0), totalTime(0)
+    ExecutorServiceImpl (Goldilocks &fr, Config &config, Prover &prover) : fr(fr), config(config), prover(prover), counter(0), totalGas(0), totalTime(0), lastTotalGas(0)
     {
+        lastTotalTime.tv_sec = 0;
+        lastTotalTime.tv_usec = 0;
         pthread_mutex_init(&mutex, NULL);
     };
     void lock(void) { pthread_mutex_lock(&mutex); };

--- a/test/service/executor/executor_client.cpp
+++ b/test/service/executor/executor_client.cpp
@@ -26,6 +26,22 @@ void ExecutorClient::waitForThread (void)
     pthread_join(t, NULL);
 }
 
+void ExecutorClient::runThreads (void)
+{
+    for (uint64_t i=0; i<EXECUTOR_CLIENT_MULTITHREAD_N_THREADS; i++)
+    {
+        pthread_create(&threads[i], NULL, executorClientThreads, this);
+    }
+}
+
+void ExecutorClient::waitForThreads (void)
+{
+    for (uint64_t i=0; i<EXECUTOR_CLIENT_MULTITHREAD_N_THREADS; i++)
+    {
+        pthread_join(threads[i], NULL);
+    }
+}
+
 bool ExecutorClient::ProcessBatch (void)
 {
     TimerStart(EXECUTOR_CLIENT_PROCESS_BATCH);
@@ -99,7 +115,7 @@ bool ExecutorClient::ProcessBatch (void)
     return true;
 }
 
-void* executorClientThread(void* arg)
+void* executorClientThread (void* arg)
 {
     cout << "executorClientThread() started" << endl;
     string uuid;
@@ -109,7 +125,26 @@ void* executorClientThread(void* arg)
     sleep(1);
 
     // Execute should block and succeed
-    cout << "executorClientThread() calling Execute()" << endl;
+    cout << "executorClientThread() calling pClient->ProcessBatch()" << endl;
     pClient->ProcessBatch();
+    return NULL;
+}
+
+void* executorClientThreads (void* arg)
+{
+    //cout << "executorClientThreads() started" << endl;
+    string uuid;
+    ExecutorClient *pClient = (ExecutorClient *)arg;
+
+    // Allow service to initialize
+    sleep(1);
+
+    // Execute should block and succeed
+    //cout << "executorClientThreads() calling pClient->ProcessBatch()" << endl;
+    for(uint64_t i=0; i<EXECUTOR_CLIENT_MULTITHREAD_N_FILES; i++)
+    {
+        pClient->ProcessBatch();
+    }
+
     return NULL;
 }

--- a/test/service/executor/executor_client.hpp
+++ b/test/service/executor/executor_client.hpp
@@ -10,6 +10,9 @@
 #include "goldilocks_base_field.hpp"
 #include "prover.hpp"
 
+#define EXECUTOR_CLIENT_MULTITHREAD_N_THREADS  100
+#define EXECUTOR_CLIENT_MULTITHREAD_N_FILES 100
+
 class ExecutorClient
 {
 public:
@@ -17,15 +20,23 @@ public:
     const Config &config;
     executor::v1::ExecutorService::Stub * stub;
     pthread_t t; // Client thread
+    pthread_t threads[EXECUTOR_CLIENT_MULTITHREAD_N_THREADS]; // Client threads
 
 public:
     ExecutorClient (Goldilocks &fr, const Config &config);
 
+    // Mono-thread
     void runThread (void);
     void waitForThread (void);
+
+    // Multi-thread
+    void runThreads (void);
+    void waitForThreads (void);
+
     bool ProcessBatch (void);
 };
 
-void* executorClientThread (void* arg);
+void* executorClientThread  (void* arg); // One process batch
+void* executorClientThreads (void* arg); // Many process batches
 
 #endif


### PR DESCRIPTION
- Add executor client multithread test.
- Calculate the total executor throughput in gas/s, every second or more.