### PR TITLE
Fix SMT set hash counter

### DIFF
--- a/src/statedb/smt.cpp
+++ b/src/statedb/smt.cpp
@@ -434,9 +434,6 @@ zkresult Smt::set (Database &db, const Goldilocks::Element (&oldRoot)[4], const 
                     // Store them in siblings
                     siblings[level+1] = dbValue;
 
-                    // Increment the counter
-                    proofHashCounter += 1;
-
                     // If it is a leaf node
                     if ( siblings[level+1].size()>8 && fr.equal( siblings[level+1][8], fr.one() ) )
                     {
@@ -465,7 +462,7 @@ zkresult Smt::set (Database &db, const Goldilocks::Element (&oldRoot)[4], const 
                         fea2scalar(fr, val, valA);
 
                         // Increment the counter
-                        proofHashCounter += 1;
+                        proofHashCounter += 2;
 
                         // Store the key in rKey
                         Goldilocks::Element rKey[4];


### PR DESCRIPTION
Port proverjs fix in SMT set hash counter, which was causing a verification error.