### PR TITLE
Fix preLaunchTask errors in launch.json file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "C/C++: gcc build",
+            "preLaunchTask": "Build zkProver",
             "miDebuggerPath": "/usr/bin/gdb"
         },
         {
@@ -46,7 +46,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "C/C++: gcc build",
+            "preLaunchTask": "Build zkProver",
             "miDebuggerPath": "/usr/bin/gdb"
         },
         {
@@ -70,7 +70,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "C/C++: gcc build",
+            "preLaunchTask": "Build zkProver",
             "miDebuggerPath": "/usr/bin/gdb"
         },
         {


### PR DESCRIPTION
The preLaunchTask for some entries of the launch.json was not updated. This generates an error when trying to run the binary using F5 from VSCODE, as the build task was not found and therefore it could run the binary without build the binary with the last changes.