### PR TITLE
Added some improvements to the StateDB class (local and remote)

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -127,6 +127,12 @@ void Config::load(json &config)
     {
         saveDbReadsToFile = config["saveDbReadsToFile"];
     }
+    saveDbReadsToFileOnChange = false;
+    if (config.contains("saveDbReadsToFileOnChange") &&
+        config["saveDbReadsToFileOnChange"].is_boolean())
+    {
+        saveDbReadsToFileOnChange = config["saveDbReadsToFileOnChange"];
+    }
     saveInputToFile = false;
     if (config.contains("saveInputToFile") &&
         config["saveInputToFile"].is_boolean())
@@ -504,6 +510,8 @@ void Config::print(void)
         cout << "    saveInputToFile=true" << endl;
     if (saveDbReadsToFile)
         cout << "    saveDbReadsToFile=true" << endl;
+    if (saveDbReadsToFileOnChange)
+        cout << "    saveDbReadsToFileOnChange=true" << endl;
     if (saveOutputToFile)
         cout << "    saveOutputToFile=true" << endl;
     if (opcodeTracer)

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -33,6 +33,7 @@ public:
     bool useMainExecGenerated;
     bool saveInputToFile;
     bool saveDbReadsToFile;
+    bool saveDbReadsToFileOnChange;
     bool saveOutputToFile;
     bool opcodeTracer;
     bool logRemoteDbReads;

--- a/src/grpc/gen/statedb.grpc.pb.cc
+++ b/src/grpc/gen/statedb.grpc.pb.cc
@@ -27,6 +27,8 @@ static const char* StateDBService_method_names[] = {
   "/statedb.v1.StateDBService/Get",
   "/statedb.v1.StateDBService/SetProgram",
   "/statedb.v1.StateDBService/GetProgram",
+  "/statedb.v1.StateDBService/LoadDB",
+  "/statedb.v1.StateDBService/LoadProgramDB",
   "/statedb.v1.StateDBService/Flush",
 };
 
@@ -41,7 +43,9 @@ StateDBService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& cha
   , rpcmethod_Get_(StateDBService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SetProgram_(StateDBService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_GetProgram_(StateDBService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Flush_(StateDBService_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_LoadDB_(StateDBService_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_LoadProgramDB_(StateDBService_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Flush_(StateDBService_method_names[6], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status StateDBService::Stub::Set(::grpc::ClientContext* context, const ::statedb::v1::SetRequest& request, ::statedb::v1::SetResponse* response) {
@@ -156,6 +160,62 @@ void StateDBService::Stub::experimental_async::GetProgram(::grpc::ClientContext*
   return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::statedb::v1::GetProgramResponse>::Create(channel_.get(), cq, rpcmethod_GetProgram_, context, request, false);
 }
 
+::grpc::Status StateDBService::Stub::LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::google::protobuf::Empty* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_LoadDB_, context, request, response);
+}
+
+void StateDBService::Stub::experimental_async::LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_LoadDB_, context, request, response, std::move(f));
+}
+
+void StateDBService::Stub::experimental_async::LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_LoadDB_, context, request, response, std::move(f));
+}
+
+void StateDBService::Stub::experimental_async::LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_LoadDB_, context, request, response, reactor);
+}
+
+void StateDBService::Stub::experimental_async::LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_LoadDB_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* StateDBService::Stub::AsyncLoadDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_LoadDB_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* StateDBService::Stub::PrepareAsyncLoadDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_LoadDB_, context, request, false);
+}
+
+::grpc::Status StateDBService::Stub::LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::google::protobuf::Empty* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_LoadProgramDB_, context, request, response);
+}
+
+void StateDBService::Stub::experimental_async::LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_LoadProgramDB_, context, request, response, std::move(f));
+}
+
+void StateDBService::Stub::experimental_async::LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_LoadProgramDB_, context, request, response, std::move(f));
+}
+
+void StateDBService::Stub::experimental_async::LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_LoadProgramDB_, context, request, response, reactor);
+}
+
+void StateDBService::Stub::experimental_async::LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_LoadProgramDB_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* StateDBService::Stub::AsyncLoadProgramDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_LoadProgramDB_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* StateDBService::Stub::PrepareAsyncLoadProgramDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::google::protobuf::Empty>::Create(channel_.get(), cq, rpcmethod_LoadProgramDB_, context, request, false);
+}
+
 ::grpc::Status StateDBService::Stub::Flush(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::google::protobuf::Empty* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Flush_, context, request, response);
 }
@@ -228,6 +288,26 @@ StateDBService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       StateDBService_method_names[4],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< StateDBService::Service, ::statedb::v1::LoadDBRequest, ::google::protobuf::Empty>(
+          [](StateDBService::Service* service,
+             ::grpc_impl::ServerContext* ctx,
+             const ::statedb::v1::LoadDBRequest* req,
+             ::google::protobuf::Empty* resp) {
+               return service->LoadDB(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      StateDBService_method_names[5],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< StateDBService::Service, ::statedb::v1::LoadProgramDBRequest, ::google::protobuf::Empty>(
+          [](StateDBService::Service* service,
+             ::grpc_impl::ServerContext* ctx,
+             const ::statedb::v1::LoadProgramDBRequest* req,
+             ::google::protobuf::Empty* resp) {
+               return service->LoadProgramDB(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      StateDBService_method_names[6],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< StateDBService::Service, ::google::protobuf::Empty, ::google::protobuf::Empty>(
           [](StateDBService::Service* service,
              ::grpc_impl::ServerContext* ctx,
@@ -262,6 +342,20 @@ StateDBService::Service::~Service() {
 }
 
 ::grpc::Status StateDBService::Service::GetProgram(::grpc::ServerContext* context, const ::statedb::v1::GetProgramRequest* request, ::statedb::v1::GetProgramResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status StateDBService::Service::LoadDB(::grpc::ServerContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status StateDBService::Service::LoadProgramDB(::grpc::ServerContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/grpc/gen/statedb.grpc.pb.h
+++ b/src/grpc/gen/statedb.grpc.pb.h
@@ -74,6 +74,20 @@ class StateDBService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::statedb::v1::GetProgramResponse>> PrepareAsyncGetProgram(::grpc::ClientContext* context, const ::statedb::v1::GetProgramRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::statedb::v1::GetProgramResponse>>(PrepareAsyncGetProgramRaw(context, request, cq));
     }
+    virtual ::grpc::Status LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncLoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncLoadDBRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncLoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncLoadDBRaw(context, request, cq));
+    }
+    virtual ::grpc::Status LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::google::protobuf::Empty* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncLoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncLoadProgramDBRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> PrepareAsyncLoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(PrepareAsyncLoadProgramDBRaw(context, request, cq));
+    }
     virtual ::grpc::Status Flush(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::google::protobuf::Empty* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>> AsyncFlush(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>>(AsyncFlushRaw(context, request, cq));
@@ -132,6 +146,30 @@ class StateDBService final {
       #else
       virtual void GetProgram(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::statedb::v1::GetProgramResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
+      virtual void LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      virtual void LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
       virtual void Flush(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       virtual void Flush(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -161,6 +199,10 @@ class StateDBService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::statedb::v1::SetProgramResponse>* PrepareAsyncSetProgramRaw(::grpc::ClientContext* context, const ::statedb::v1::SetProgramRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::statedb::v1::GetProgramResponse>* AsyncGetProgramRaw(::grpc::ClientContext* context, const ::statedb::v1::GetProgramRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::statedb::v1::GetProgramResponse>* PrepareAsyncGetProgramRaw(::grpc::ClientContext* context, const ::statedb::v1::GetProgramRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncLoadDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncLoadDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncLoadProgramDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncLoadProgramDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* AsyncFlushRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::google::protobuf::Empty>* PrepareAsyncFlushRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
   };
@@ -194,6 +236,20 @@ class StateDBService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::statedb::v1::GetProgramResponse>> PrepareAsyncGetProgram(::grpc::ClientContext* context, const ::statedb::v1::GetProgramRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::statedb::v1::GetProgramResponse>>(PrepareAsyncGetProgramRaw(context, request, cq));
+    }
+    ::grpc::Status LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncLoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncLoadDBRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncLoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncLoadDBRaw(context, request, cq));
+    }
+    ::grpc::Status LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::google::protobuf::Empty* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncLoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(AsyncLoadProgramDBRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> PrepareAsyncLoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>>(PrepareAsyncLoadProgramDBRaw(context, request, cq));
     }
     ::grpc::Status Flush(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::google::protobuf::Empty* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>> AsyncFlush(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
@@ -253,6 +309,30 @@ class StateDBService final {
       #else
       void GetProgram(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::statedb::v1::GetProgramResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
+      void LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      void LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void LoadDB(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void LoadDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      void LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      void LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void LoadProgramDB(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void LoadProgramDB(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
       void Flush(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       void Flush(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::google::protobuf::Empty* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -284,12 +364,18 @@ class StateDBService final {
     ::grpc::ClientAsyncResponseReader< ::statedb::v1::SetProgramResponse>* PrepareAsyncSetProgramRaw(::grpc::ClientContext* context, const ::statedb::v1::SetProgramRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::statedb::v1::GetProgramResponse>* AsyncGetProgramRaw(::grpc::ClientContext* context, const ::statedb::v1::GetProgramRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::statedb::v1::GetProgramResponse>* PrepareAsyncGetProgramRaw(::grpc::ClientContext* context, const ::statedb::v1::GetProgramRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncLoadDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncLoadDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadDBRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncLoadProgramDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncLoadProgramDBRaw(::grpc::ClientContext* context, const ::statedb::v1::LoadProgramDBRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* AsyncFlushRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::google::protobuf::Empty>* PrepareAsyncFlushRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_Set_;
     const ::grpc::internal::RpcMethod rpcmethod_Get_;
     const ::grpc::internal::RpcMethod rpcmethod_SetProgram_;
     const ::grpc::internal::RpcMethod rpcmethod_GetProgram_;
+    const ::grpc::internal::RpcMethod rpcmethod_LoadDB_;
+    const ::grpc::internal::RpcMethod rpcmethod_LoadProgramDB_;
     const ::grpc::internal::RpcMethod rpcmethod_Flush_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
@@ -302,6 +388,8 @@ class StateDBService final {
     virtual ::grpc::Status Get(::grpc::ServerContext* context, const ::statedb::v1::GetRequest* request, ::statedb::v1::GetResponse* response);
     virtual ::grpc::Status SetProgram(::grpc::ServerContext* context, const ::statedb::v1::SetProgramRequest* request, ::statedb::v1::SetProgramResponse* response);
     virtual ::grpc::Status GetProgram(::grpc::ServerContext* context, const ::statedb::v1::GetProgramRequest* request, ::statedb::v1::GetProgramResponse* response);
+    virtual ::grpc::Status LoadDB(::grpc::ServerContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response);
+    virtual ::grpc::Status LoadProgramDB(::grpc::ServerContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response);
     virtual ::grpc::Status Flush(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response);
   };
   template <class BaseClass>
@@ -385,12 +473,52 @@ class StateDBService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_LoadDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_LoadDB() {
+      ::grpc::Service::MarkMethodAsync(4);
+    }
+    ~WithAsyncMethod_LoadDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadDB(::grpc::ServerContext* context, ::statedb::v1::LoadDBRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_LoadProgramDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_LoadProgramDB() {
+      ::grpc::Service::MarkMethodAsync(5);
+    }
+    ~WithAsyncMethod_LoadProgramDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadProgramDB(::grpc::ServerContext* context, ::statedb::v1::LoadProgramDBRequest* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_Flush : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_Flush() {
-      ::grpc::Service::MarkMethodAsync(4);
+      ::grpc::Service::MarkMethodAsync(6);
     }
     ~WithAsyncMethod_Flush() override {
       BaseClassMustBeDerivedFromService(this);
@@ -401,10 +529,10 @@ class StateDBService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFlush(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::google::protobuf::Empty>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Set<WithAsyncMethod_Get<WithAsyncMethod_SetProgram<WithAsyncMethod_GetProgram<WithAsyncMethod_Flush<Service > > > > > AsyncService;
+  typedef WithAsyncMethod_Set<WithAsyncMethod_Get<WithAsyncMethod_SetProgram<WithAsyncMethod_GetProgram<WithAsyncMethod_LoadDB<WithAsyncMethod_LoadProgramDB<WithAsyncMethod_Flush<Service > > > > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_Set : public BaseClass {
    private:
@@ -594,6 +722,100 @@ class StateDBService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_LoadDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_LoadDB() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(4,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::statedb::v1::LoadDBRequest, ::google::protobuf::Empty>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response) { return this->LoadDB(context, request, response); }));}
+    void SetMessageAllocatorFor_LoadDB(
+        ::grpc::experimental::MessageAllocator< ::statedb::v1::LoadDBRequest, ::google::protobuf::Empty>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(4);
+    #endif
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::statedb::v1::LoadDBRequest, ::google::protobuf::Empty>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_LoadDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* LoadDB(
+      ::grpc::CallbackServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* LoadDB(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
+  class ExperimentalWithCallbackMethod_LoadProgramDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_LoadProgramDB() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(5,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::statedb::v1::LoadProgramDBRequest, ::google::protobuf::Empty>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response) { return this->LoadProgramDB(context, request, response); }));}
+    void SetMessageAllocatorFor_LoadProgramDB(
+        ::grpc::experimental::MessageAllocator< ::statedb::v1::LoadProgramDBRequest, ::google::protobuf::Empty>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(5);
+    #endif
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::statedb::v1::LoadProgramDBRequest, ::google::protobuf::Empty>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_LoadProgramDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* LoadProgramDB(
+      ::grpc::CallbackServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* LoadProgramDB(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_Flush : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -604,7 +826,7 @@ class StateDBService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(4,
+        MarkMethodCallback(6,
           new ::grpc_impl::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -616,9 +838,9 @@ class StateDBService final {
     void SetMessageAllocatorFor_Flush(
         ::grpc::experimental::MessageAllocator< ::google::protobuf::Empty, ::google::protobuf::Empty>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(4);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(4);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(6);
     #endif
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::google::protobuf::Empty>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -641,10 +863,10 @@ class StateDBService final {
       { return nullptr; }
   };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_Set<ExperimentalWithCallbackMethod_Get<ExperimentalWithCallbackMethod_SetProgram<ExperimentalWithCallbackMethod_GetProgram<ExperimentalWithCallbackMethod_Flush<Service > > > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_Set<ExperimentalWithCallbackMethod_Get<ExperimentalWithCallbackMethod_SetProgram<ExperimentalWithCallbackMethod_GetProgram<ExperimentalWithCallbackMethod_LoadDB<ExperimentalWithCallbackMethod_LoadProgramDB<ExperimentalWithCallbackMethod_Flush<Service > > > > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_Set<ExperimentalWithCallbackMethod_Get<ExperimentalWithCallbackMethod_SetProgram<ExperimentalWithCallbackMethod_GetProgram<ExperimentalWithCallbackMethod_Flush<Service > > > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_Set<ExperimentalWithCallbackMethod_Get<ExperimentalWithCallbackMethod_SetProgram<ExperimentalWithCallbackMethod_GetProgram<ExperimentalWithCallbackMethod_LoadDB<ExperimentalWithCallbackMethod_LoadProgramDB<ExperimentalWithCallbackMethod_Flush<Service > > > > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Set : public BaseClass {
    private:
@@ -714,12 +936,46 @@ class StateDBService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_LoadDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_LoadDB() {
+      ::grpc::Service::MarkMethodGeneric(4);
+    }
+    ~WithGenericMethod_LoadDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_LoadProgramDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_LoadProgramDB() {
+      ::grpc::Service::MarkMethodGeneric(5);
+    }
+    ~WithGenericMethod_LoadProgramDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_Flush : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_Flush() {
-      ::grpc::Service::MarkMethodGeneric(4);
+      ::grpc::Service::MarkMethodGeneric(6);
     }
     ~WithGenericMethod_Flush() override {
       BaseClassMustBeDerivedFromService(this);
@@ -811,12 +1067,52 @@ class StateDBService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_LoadDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_LoadDB() {
+      ::grpc::Service::MarkMethodRaw(4);
+    }
+    ~WithRawMethod_LoadDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadDB(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_LoadProgramDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_LoadProgramDB() {
+      ::grpc::Service::MarkMethodRaw(5);
+    }
+    ~WithRawMethod_LoadProgramDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadProgramDB(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_Flush : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_Flush() {
-      ::grpc::Service::MarkMethodRaw(4);
+      ::grpc::Service::MarkMethodRaw(6);
     }
     ~WithRawMethod_Flush() override {
       BaseClassMustBeDerivedFromService(this);
@@ -827,7 +1123,7 @@ class StateDBService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFlush(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -983,6 +1279,82 @@ class StateDBService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_LoadDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_LoadDB() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(4,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->LoadDB(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_LoadDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* LoadDB(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* LoadDB(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_LoadProgramDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_LoadProgramDB() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(5,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->LoadProgramDB(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_LoadProgramDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* LoadProgramDB(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* LoadProgramDB(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_Flush : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -993,7 +1365,7 @@ class StateDBService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(4,
+        MarkMethodRawCallback(6,
           new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -1129,12 +1501,66 @@ class StateDBService final {
     virtual ::grpc::Status StreamedGetProgram(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::statedb::v1::GetProgramRequest,::statedb::v1::GetProgramResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_LoadDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_LoadDB() {
+      ::grpc::Service::MarkMethodStreamed(4,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::statedb::v1::LoadDBRequest, ::google::protobuf::Empty>(
+            [this](::grpc_impl::ServerContext* context,
+                   ::grpc_impl::ServerUnaryStreamer<
+                     ::statedb::v1::LoadDBRequest, ::google::protobuf::Empty>* streamer) {
+                       return this->StreamedLoadDB(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_LoadDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status LoadDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedLoadDB(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::statedb::v1::LoadDBRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_LoadProgramDB : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_LoadProgramDB() {
+      ::grpc::Service::MarkMethodStreamed(5,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::statedb::v1::LoadProgramDBRequest, ::google::protobuf::Empty>(
+            [this](::grpc_impl::ServerContext* context,
+                   ::grpc_impl::ServerUnaryStreamer<
+                     ::statedb::v1::LoadProgramDBRequest, ::google::protobuf::Empty>* streamer) {
+                       return this->StreamedLoadProgramDB(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_LoadProgramDB() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* /*context*/, const ::statedb::v1::LoadProgramDBRequest* /*request*/, ::google::protobuf::Empty* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedLoadProgramDB(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::statedb::v1::LoadProgramDBRequest,::google::protobuf::Empty>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_Flush : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_Flush() {
-      ::grpc::Service::MarkMethodStreamed(4,
+      ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler<
           ::google::protobuf::Empty, ::google::protobuf::Empty>(
             [this](::grpc_impl::ServerContext* context,
@@ -1155,9 +1581,9 @@ class StateDBService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedFlush(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::google::protobuf::Empty>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Set<WithStreamedUnaryMethod_Get<WithStreamedUnaryMethod_SetProgram<WithStreamedUnaryMethod_GetProgram<WithStreamedUnaryMethod_Flush<Service > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Set<WithStreamedUnaryMethod_Get<WithStreamedUnaryMethod_SetProgram<WithStreamedUnaryMethod_GetProgram<WithStreamedUnaryMethod_LoadDB<WithStreamedUnaryMethod_LoadProgramDB<WithStreamedUnaryMethod_Flush<Service > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Set<WithStreamedUnaryMethod_Get<WithStreamedUnaryMethod_SetProgram<WithStreamedUnaryMethod_GetProgram<WithStreamedUnaryMethod_Flush<Service > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Set<WithStreamedUnaryMethod_Get<WithStreamedUnaryMethod_SetProgram<WithStreamedUnaryMethod_GetProgram<WithStreamedUnaryMethod_LoadDB<WithStreamedUnaryMethod_LoadProgramDB<WithStreamedUnaryMethod_Flush<Service > > > > > > > StreamedService;
 };
 
 }  // namespace v1

--- a/src/grpc/gen/statedb.pb.cc
+++ b/src/grpc/gen/statedb.pb.cc
@@ -14,9 +14,14 @@
 #include <google/protobuf/wire_format.h>
 // @@protoc_insertion_point(includes)
 #include <google/protobuf/port_def.inc>
+extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_FeList_statedb_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_Fea_statedb_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_GetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_LoadDBRequest_InputDbEntry_DoNotUse_statedb_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_statedb_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_ResultCode_statedb_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_SetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_SetResponse_SiblingsEntry_DoNotUse_statedb_2eproto;
 extern PROTOBUF_INTERNAL_EXPORT_statedb_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_SiblingList_statedb_2eproto;
 namespace statedb {
@@ -41,10 +46,30 @@ class GetProgramRequestDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GetProgramRequest> _instance;
 } _GetProgramRequest_default_instance_;
+class LoadDBRequest_InputDbEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<LoadDBRequest_InputDbEntry_DoNotUse> _instance;
+} _LoadDBRequest_InputDbEntry_DoNotUse_default_instance_;
+class LoadDBRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<LoadDBRequest> _instance;
+} _LoadDBRequest_default_instance_;
+class LoadProgramDBRequest_InputProgramDbEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<LoadProgramDBRequest_InputProgramDbEntry_DoNotUse> _instance;
+} _LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_default_instance_;
+class LoadProgramDBRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<LoadProgramDBRequest> _instance;
+} _LoadProgramDBRequest_default_instance_;
 class SetResponse_SiblingsEntry_DoNotUseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetResponse_SiblingsEntry_DoNotUse> _instance;
 } _SetResponse_SiblingsEntry_DoNotUse_default_instance_;
+class SetResponse_DbReadLogEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetResponse_DbReadLogEntry_DoNotUse> _instance;
+} _SetResponse_DbReadLogEntry_DoNotUse_default_instance_;
 class SetResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SetResponse> _instance;
@@ -53,6 +78,10 @@ class GetResponse_SiblingsEntry_DoNotUseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GetResponse_SiblingsEntry_DoNotUse> _instance;
 } _GetResponse_SiblingsEntry_DoNotUse_default_instance_;
+class GetResponse_DbReadLogEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GetResponse_DbReadLogEntry_DoNotUse> _instance;
+} _GetResponse_DbReadLogEntry_DoNotUse_default_instance_;
 class GetResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<GetResponse> _instance;
@@ -69,6 +98,10 @@ class FeaDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<Fea> _instance;
 } _Fea_default_instance_;
+class FeListDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<FeList> _instance;
+} _FeList_default_instance_;
 class SiblingListDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<SiblingList> _instance;
@@ -79,6 +112,20 @@ class ResultCodeDefaultTypeInternal {
 } _ResultCode_default_instance_;
 }  // namespace v1
 }  // namespace statedb
+static void InitDefaultsscc_info_FeList_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_FeList_default_instance_;
+    new (ptr) ::statedb::v1::FeList();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::statedb::v1::FeList::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_FeList_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_FeList_statedb_2eproto}, {}};
+
 static void InitDefaultsscc_info_Fea_statedb_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -149,11 +196,26 @@ static void InitDefaultsscc_info_GetResponse_statedb_2eproto() {
   ::statedb::v1::GetResponse::InitAsDefaultInstance();
 }
 
-::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<3> scc_info_GetResponse_statedb_2eproto =
-    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 3, 0, InitDefaultsscc_info_GetResponse_statedb_2eproto}, {
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<4> scc_info_GetResponse_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 4, 0, InitDefaultsscc_info_GetResponse_statedb_2eproto}, {
       &scc_info_Fea_statedb_2eproto.base,
       &scc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2eproto.base,
+      &scc_info_GetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto.base,
       &scc_info_ResultCode_statedb_2eproto.base,}};
+
+static void InitDefaultsscc_info_GetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_GetResponse_DbReadLogEntry_DoNotUse_default_instance_;
+    new (ptr) ::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse();
+  }
+  ::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_GetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_GetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto}, {
+      &scc_info_FeList_statedb_2eproto.base,}};
 
 static void InitDefaultsscc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -168,6 +230,63 @@ static void InitDefaultsscc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2epr
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2eproto}, {
       &scc_info_SiblingList_statedb_2eproto.base,}};
+
+static void InitDefaultsscc_info_LoadDBRequest_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_LoadDBRequest_default_instance_;
+    new (ptr) ::statedb::v1::LoadDBRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::statedb::v1::LoadDBRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_LoadDBRequest_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_LoadDBRequest_statedb_2eproto}, {
+      &scc_info_LoadDBRequest_InputDbEntry_DoNotUse_statedb_2eproto.base,}};
+
+static void InitDefaultsscc_info_LoadDBRequest_InputDbEntry_DoNotUse_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_LoadDBRequest_InputDbEntry_DoNotUse_default_instance_;
+    new (ptr) ::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse();
+  }
+  ::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_LoadDBRequest_InputDbEntry_DoNotUse_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_LoadDBRequest_InputDbEntry_DoNotUse_statedb_2eproto}, {
+      &scc_info_FeList_statedb_2eproto.base,}};
+
+static void InitDefaultsscc_info_LoadProgramDBRequest_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_LoadProgramDBRequest_default_instance_;
+    new (ptr) ::statedb::v1::LoadProgramDBRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::statedb::v1::LoadProgramDBRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_LoadProgramDBRequest_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_LoadProgramDBRequest_statedb_2eproto}, {
+      &scc_info_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_statedb_2eproto.base,}};
+
+static void InitDefaultsscc_info_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_default_instance_;
+    new (ptr) ::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse();
+  }
+  ::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_statedb_2eproto}, {}};
 
 static void InitDefaultsscc_info_ResultCode_statedb_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -239,11 +358,26 @@ static void InitDefaultsscc_info_SetResponse_statedb_2eproto() {
   ::statedb::v1::SetResponse::InitAsDefaultInstance();
 }
 
-::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<3> scc_info_SetResponse_statedb_2eproto =
-    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 3, 0, InitDefaultsscc_info_SetResponse_statedb_2eproto}, {
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<4> scc_info_SetResponse_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 4, 0, InitDefaultsscc_info_SetResponse_statedb_2eproto}, {
       &scc_info_Fea_statedb_2eproto.base,
       &scc_info_SetResponse_SiblingsEntry_DoNotUse_statedb_2eproto.base,
+      &scc_info_SetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto.base,
       &scc_info_ResultCode_statedb_2eproto.base,}};
+
+static void InitDefaultsscc_info_SetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::statedb::v1::_SetResponse_DbReadLogEntry_DoNotUse_default_instance_;
+    new (ptr) ::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse();
+  }
+  ::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_SetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_SetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto}, {
+      &scc_info_FeList_statedb_2eproto.base,}};
 
 static void InitDefaultsscc_info_SetResponse_SiblingsEntry_DoNotUse_statedb_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -287,7 +421,7 @@ static void InitDefaultsscc_info_Version_statedb_2eproto() {
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_Version_statedb_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_Version_statedb_2eproto}, {}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_statedb_2eproto[14];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_statedb_2eproto[21];
 static const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* file_level_enum_descriptors_statedb_2eproto[1];
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_statedb_2eproto = nullptr;
 
@@ -308,6 +442,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetRequest, value_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetRequest, persistent_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetRequest, details_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::SetRequest, get_db_read_log_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -316,6 +451,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetRequest, root_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetRequest, key_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetRequest, details_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::GetRequest, get_db_read_log_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetProgramRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -330,6 +466,38 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetProgramRequest, key_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse, _has_bits_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse, key_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest, input_db_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadDBRequest, persistent_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse, _has_bits_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse, key_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest, input_program_db_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::LoadProgramDBRequest, persistent_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_SiblingsEntry_DoNotUse, _has_bits_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_SiblingsEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -337,6 +505,15 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_SiblingsEntry_DoNotUse, key_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_SiblingsEntry_DoNotUse, value_),
+  0,
+  1,
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse, _has_bits_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse, key_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse, value_),
   0,
   1,
   ~0u,  // no _has_bits_
@@ -355,6 +532,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse, new_value_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse, mode_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse, proof_hash_counter_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse, db_read_log_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetResponse, result_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_SiblingsEntry_DoNotUse, _has_bits_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_SiblingsEntry_DoNotUse, _internal_metadata_),
@@ -363,6 +541,15 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_SiblingsEntry_DoNotUse, key_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_SiblingsEntry_DoNotUse, value_),
+  0,
+  1,
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse, _has_bits_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse, key_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse, value_),
   0,
   1,
   ~0u,  // no _has_bits_
@@ -378,6 +565,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse, is_old0_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse, value_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse, proof_hash_counter_),
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse, db_read_log_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::GetResponse, result_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SetProgramResponse, _internal_metadata_),
@@ -402,6 +590,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
   PROTOBUF_FIELD_OFFSET(::statedb::v1::Fea, fe2_),
   PROTOBUF_FIELD_OFFSET(::statedb::v1::Fea, fe3_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::FeList, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::statedb::v1::FeList, fe_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::statedb::v1::SiblingList, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -417,18 +611,25 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_statedb_2eproto::offsets[] PRO
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::statedb::v1::Version)},
   { 6, -1, sizeof(::statedb::v1::SetRequest)},
-  { 16, -1, sizeof(::statedb::v1::GetRequest)},
-  { 24, -1, sizeof(::statedb::v1::SetProgramRequest)},
-  { 32, -1, sizeof(::statedb::v1::GetProgramRequest)},
-  { 38, 45, sizeof(::statedb::v1::SetResponse_SiblingsEntry_DoNotUse)},
-  { 47, -1, sizeof(::statedb::v1::SetResponse)},
-  { 64, 71, sizeof(::statedb::v1::GetResponse_SiblingsEntry_DoNotUse)},
-  { 73, -1, sizeof(::statedb::v1::GetResponse)},
-  { 87, -1, sizeof(::statedb::v1::SetProgramResponse)},
-  { 93, -1, sizeof(::statedb::v1::GetProgramResponse)},
-  { 100, -1, sizeof(::statedb::v1::Fea)},
-  { 109, -1, sizeof(::statedb::v1::SiblingList)},
-  { 115, -1, sizeof(::statedb::v1::ResultCode)},
+  { 17, -1, sizeof(::statedb::v1::GetRequest)},
+  { 26, -1, sizeof(::statedb::v1::SetProgramRequest)},
+  { 34, -1, sizeof(::statedb::v1::GetProgramRequest)},
+  { 40, 47, sizeof(::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse)},
+  { 49, -1, sizeof(::statedb::v1::LoadDBRequest)},
+  { 56, 63, sizeof(::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse)},
+  { 65, -1, sizeof(::statedb::v1::LoadProgramDBRequest)},
+  { 72, 79, sizeof(::statedb::v1::SetResponse_SiblingsEntry_DoNotUse)},
+  { 81, 88, sizeof(::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse)},
+  { 90, -1, sizeof(::statedb::v1::SetResponse)},
+  { 108, 115, sizeof(::statedb::v1::GetResponse_SiblingsEntry_DoNotUse)},
+  { 117, 124, sizeof(::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse)},
+  { 126, -1, sizeof(::statedb::v1::GetResponse)},
+  { 141, -1, sizeof(::statedb::v1::SetProgramResponse)},
+  { 147, -1, sizeof(::statedb::v1::GetProgramResponse)},
+  { 154, -1, sizeof(::statedb::v1::Fea)},
+  { 163, -1, sizeof(::statedb::v1::FeList)},
+  { 169, -1, sizeof(::statedb::v1::SiblingList)},
+  { 175, -1, sizeof(::statedb::v1::ResultCode)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -437,13 +638,20 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_GetRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_SetProgramRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_GetProgramRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_LoadDBRequest_InputDbEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_LoadDBRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_LoadProgramDBRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_SetResponse_SiblingsEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_SetResponse_DbReadLogEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_SetResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_GetResponse_SiblingsEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_GetResponse_DbReadLogEntry_DoNotUse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_GetResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_SetProgramResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_GetProgramResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_Fea_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_FeList_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_SiblingList_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::statedb::v1::_ResultCode_default_instance_),
 };
@@ -451,83 +659,110 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
 const char descriptor_table_protodef_statedb_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\rstatedb.proto\022\nstatedb.v1\032\033google/prot"
   "obuf/empty.proto\"\031\n\007Version\022\016\n\006v0_0_1\030\001 "
-  "\001(\t\"\201\001\n\nSetRequest\022!\n\010old_root\030\001 \001(\0132\017.s"
+  "\001(\t\"\232\001\n\nSetRequest\022!\n\010old_root\030\001 \001(\0132\017.s"
   "tatedb.v1.Fea\022\034\n\003key\030\002 \001(\0132\017.statedb.v1."
   "Fea\022\r\n\005value\030\003 \001(\t\022\022\n\npersistent\030\004 \001(\010\022\017"
-  "\n\007details\030\005 \001(\010\"Z\n\nGetRequest\022\035\n\004root\030\001 "
-  "\001(\0132\017.statedb.v1.Fea\022\034\n\003key\030\002 \001(\0132\017.stat"
-  "edb.v1.Fea\022\017\n\007details\030\003 \001(\010\"S\n\021SetProgra"
-  "mRequest\022\034\n\003key\030\001 \001(\0132\017.statedb.v1.Fea\022\014"
-  "\n\004data\030\002 \001(\014\022\022\n\npersistent\030\003 \001(\010\"1\n\021GetP"
-  "rogramRequest\022\034\n\003key\030\001 \001(\0132\017.statedb.v1."
-  "Fea\"\262\003\n\013SetResponse\022!\n\010old_root\030\001 \001(\0132\017."
-  "statedb.v1.Fea\022!\n\010new_root\030\002 \001(\0132\017.state"
-  "db.v1.Fea\022\034\n\003key\030\003 \001(\0132\017.statedb.v1.Fea\022"
-  "7\n\010siblings\030\004 \003(\0132%.statedb.v1.SetRespon"
-  "se.SiblingsEntry\022 \n\007ins_key\030\005 \001(\0132\017.stat"
-  "edb.v1.Fea\022\021\n\tins_value\030\006 \001(\t\022\017\n\007is_old0"
-  "\030\007 \001(\010\022\021\n\told_value\030\010 \001(\t\022\021\n\tnew_value\030\t"
-  " \001(\t\022\014\n\004mode\030\n \001(\t\022\032\n\022proof_hash_counter"
-  "\030\013 \001(\004\022&\n\006result\030\014 \001(\0132\026.statedb.v1.Resu"
-  "ltCode\032H\n\rSiblingsEntry\022\013\n\003key\030\001 \001(\004\022&\n\005"
-  "value\030\002 \001(\0132\027.statedb.v1.SiblingList:\0028\001"
-  "\"\346\002\n\013GetResponse\022\035\n\004root\030\001 \001(\0132\017.statedb"
-  ".v1.Fea\022\034\n\003key\030\002 \001(\0132\017.statedb.v1.Fea\0227\n"
-  "\010siblings\030\003 \003(\0132%.statedb.v1.GetResponse"
-  ".SiblingsEntry\022 \n\007ins_key\030\004 \001(\0132\017.stated"
-  "b.v1.Fea\022\021\n\tins_value\030\005 \001(\t\022\017\n\007is_old0\030\006"
-  " \001(\010\022\r\n\005value\030\007 \001(\t\022\032\n\022proof_hash_counte"
-  "r\030\010 \001(\004\022&\n\006result\030\t \001(\0132\026.statedb.v1.Res"
-  "ultCode\032H\n\rSiblingsEntry\022\013\n\003key\030\001 \001(\004\022&\n"
-  "\005value\030\002 \001(\0132\027.statedb.v1.SiblingList:\0028"
-  "\001\"<\n\022SetProgramResponse\022&\n\006result\030\001 \001(\0132"
-  "\026.statedb.v1.ResultCode\"J\n\022GetProgramRes"
-  "ponse\022\014\n\004data\030\001 \001(\014\022&\n\006result\030\002 \001(\0132\026.st"
-  "atedb.v1.ResultCode\"9\n\003Fea\022\013\n\003fe0\030\001 \001(\004\022"
-  "\013\n\003fe1\030\002 \001(\004\022\013\n\003fe2\030\003 \001(\004\022\013\n\003fe3\030\004 \001(\004\"\036"
-  "\n\013SiblingList\022\017\n\007sibling\030\001 \003(\004\"\317\001\n\nResul"
-  "tCode\022)\n\004code\030\001 \001(\0162\033.statedb.v1.ResultC"
-  "ode.Code\"\225\001\n\004Code\022\024\n\020CODE_UNSPECIFIED\020\000\022"
-  "\020\n\014CODE_SUCCESS\020\001\022\031\n\025CODE_DB_KEY_NOT_FOU"
-  "ND\020\002\022\021\n\rCODE_DB_ERROR\020\003\022\027\n\023CODE_INTERNAL"
-  "_ERROR\020\004\022\036\n\032CODE_SMT_INVALID_DATA_SIZE\020\016"
-  "2\335\002\n\016StateDBService\0228\n\003Set\022\026.statedb.v1."
-  "SetRequest\032\027.statedb.v1.SetResponse\"\000\0228\n"
-  "\003Get\022\026.statedb.v1.GetRequest\032\027.statedb.v"
-  "1.GetResponse\"\000\022M\n\nSetProgram\022\035.statedb."
-  "v1.SetProgramRequest\032\036.statedb.v1.SetPro"
-  "gramResponse\"\000\022M\n\nGetProgram\022\035.statedb.v"
-  "1.GetProgramRequest\032\036.statedb.v1.GetProg"
-  "ramResponse\"\000\0229\n\005Flush\022\026.google.protobuf"
-  ".Empty\032\026.google.protobuf.Empty\"\000B5Z3gith"
-  "ub.com/0xPolygonHermez/zkevm-node/merkle"
-  "tree/pbb\006proto3"
+  "\n\007details\030\005 \001(\010\022\027\n\017get_db_read_log\030\006 \001(\010"
+  "\"s\n\nGetRequest\022\035\n\004root\030\001 \001(\0132\017.statedb.v"
+  "1.Fea\022\034\n\003key\030\002 \001(\0132\017.statedb.v1.Fea\022\017\n\007d"
+  "etails\030\003 \001(\010\022\027\n\017get_db_read_log\030\004 \001(\010\"S\n"
+  "\021SetProgramRequest\022\034\n\003key\030\001 \001(\0132\017.stated"
+  "b.v1.Fea\022\014\n\004data\030\002 \001(\014\022\022\n\npersistent\030\003 \001"
+  "(\010\"1\n\021GetProgramRequest\022\034\n\003key\030\001 \001(\0132\017.s"
+  "tatedb.v1.Fea\"\241\001\n\rLoadDBRequest\0228\n\010input"
+  "_db\030\001 \003(\0132&.statedb.v1.LoadDBRequest.Inp"
+  "utDbEntry\022\022\n\npersistent\030\002 \001(\010\032B\n\014InputDb"
+  "Entry\022\013\n\003key\030\001 \001(\t\022!\n\005value\030\002 \001(\0132\022.stat"
+  "edb.v1.FeList:\0028\001\"\261\001\n\024LoadProgramDBReque"
+  "st\022N\n\020input_program_db\030\001 \003(\01324.statedb.v"
+  "1.LoadProgramDBRequest.InputProgramDbEnt"
+  "ry\022\022\n\npersistent\030\002 \001(\010\0325\n\023InputProgramDb"
+  "Entry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"\265\004"
+  "\n\013SetResponse\022!\n\010old_root\030\001 \001(\0132\017.stated"
+  "b.v1.Fea\022!\n\010new_root\030\002 \001(\0132\017.statedb.v1."
+  "Fea\022\034\n\003key\030\003 \001(\0132\017.statedb.v1.Fea\0227\n\010sib"
+  "lings\030\004 \003(\0132%.statedb.v1.SetResponse.Sib"
+  "lingsEntry\022 \n\007ins_key\030\005 \001(\0132\017.statedb.v1"
+  ".Fea\022\021\n\tins_value\030\006 \001(\t\022\017\n\007is_old0\030\007 \001(\010"
+  "\022\021\n\told_value\030\010 \001(\t\022\021\n\tnew_value\030\t \001(\t\022\014"
+  "\n\004mode\030\n \001(\t\022\032\n\022proof_hash_counter\030\013 \001(\004"
+  "\022;\n\013db_read_log\030\014 \003(\0132&.statedb.v1.SetRe"
+  "sponse.DbReadLogEntry\022&\n\006result\030\r \001(\0132\026."
+  "statedb.v1.ResultCode\032H\n\rSiblingsEntry\022\013"
+  "\n\003key\030\001 \001(\004\022&\n\005value\030\002 \001(\0132\027.statedb.v1."
+  "SiblingList:\0028\001\032D\n\016DbReadLogEntry\022\013\n\003key"
+  "\030\001 \001(\t\022!\n\005value\030\002 \001(\0132\022.statedb.v1.FeLis"
+  "t:\0028\001\"\351\003\n\013GetResponse\022\035\n\004root\030\001 \001(\0132\017.st"
+  "atedb.v1.Fea\022\034\n\003key\030\002 \001(\0132\017.statedb.v1.F"
+  "ea\0227\n\010siblings\030\003 \003(\0132%.statedb.v1.GetRes"
+  "ponse.SiblingsEntry\022 \n\007ins_key\030\004 \001(\0132\017.s"
+  "tatedb.v1.Fea\022\021\n\tins_value\030\005 \001(\t\022\017\n\007is_o"
+  "ld0\030\006 \001(\010\022\r\n\005value\030\007 \001(\t\022\032\n\022proof_hash_c"
+  "ounter\030\010 \001(\004\022;\n\013db_read_log\030\t \003(\0132&.stat"
+  "edb.v1.GetResponse.DbReadLogEntry\022&\n\006res"
+  "ult\030\n \001(\0132\026.statedb.v1.ResultCode\032H\n\rSib"
+  "lingsEntry\022\013\n\003key\030\001 \001(\004\022&\n\005value\030\002 \001(\0132\027"
+  ".statedb.v1.SiblingList:\0028\001\032D\n\016DbReadLog"
+  "Entry\022\013\n\003key\030\001 \001(\t\022!\n\005value\030\002 \001(\0132\022.stat"
+  "edb.v1.FeList:\0028\001\"<\n\022SetProgramResponse\022"
+  "&\n\006result\030\001 \001(\0132\026.statedb.v1.ResultCode\""
+  "J\n\022GetProgramResponse\022\014\n\004data\030\001 \001(\014\022&\n\006r"
+  "esult\030\002 \001(\0132\026.statedb.v1.ResultCode\"9\n\003F"
+  "ea\022\013\n\003fe0\030\001 \001(\004\022\013\n\003fe1\030\002 \001(\004\022\013\n\003fe2\030\003 \001("
+  "\004\022\013\n\003fe3\030\004 \001(\004\"\024\n\006FeList\022\n\n\002fe\030\001 \003(\004\"\036\n\013"
+  "SiblingList\022\017\n\007sibling\030\001 \003(\004\"\317\001\n\nResultC"
+  "ode\022)\n\004code\030\001 \001(\0162\033.statedb.v1.ResultCod"
+  "e.Code\"\225\001\n\004Code\022\024\n\020CODE_UNSPECIFIED\020\000\022\020\n"
+  "\014CODE_SUCCESS\020\001\022\031\n\025CODE_DB_KEY_NOT_FOUND"
+  "\020\002\022\021\n\rCODE_DB_ERROR\020\003\022\027\n\023CODE_INTERNAL_E"
+  "RROR\020\004\022\036\n\032CODE_SMT_INVALID_DATA_SIZE\020\0162\351"
+  "\003\n\016StateDBService\0228\n\003Set\022\026.statedb.v1.Se"
+  "tRequest\032\027.statedb.v1.SetResponse\"\000\0228\n\003G"
+  "et\022\026.statedb.v1.GetRequest\032\027.statedb.v1."
+  "GetResponse\"\000\022M\n\nSetProgram\022\035.statedb.v1"
+  ".SetProgramRequest\032\036.statedb.v1.SetProgr"
+  "amResponse\"\000\022M\n\nGetProgram\022\035.statedb.v1."
+  "GetProgramRequest\032\036.statedb.v1.GetProgra"
+  "mResponse\"\000\022=\n\006LoadDB\022\031.statedb.v1.LoadD"
+  "BRequest\032\026.google.protobuf.Empty\"\000\022K\n\rLo"
+  "adProgramDB\022 .statedb.v1.LoadProgramDBRe"
+  "quest\032\026.google.protobuf.Empty\"\000\0229\n\005Flush"
+  "\022\026.google.protobuf.Empty\032\026.google.protob"
+  "uf.Empty\"\000B5Z3github.com/0xPolygonHermez"
+  "/zkevm-node/merkletree/pbb\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_statedb_2eproto_deps[1] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_statedb_2eproto_sccs[14] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_statedb_2eproto_sccs[21] = {
+  &scc_info_FeList_statedb_2eproto.base,
   &scc_info_Fea_statedb_2eproto.base,
   &scc_info_GetProgramRequest_statedb_2eproto.base,
   &scc_info_GetProgramResponse_statedb_2eproto.base,
   &scc_info_GetRequest_statedb_2eproto.base,
   &scc_info_GetResponse_statedb_2eproto.base,
+  &scc_info_GetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto.base,
   &scc_info_GetResponse_SiblingsEntry_DoNotUse_statedb_2eproto.base,
+  &scc_info_LoadDBRequest_statedb_2eproto.base,
+  &scc_info_LoadDBRequest_InputDbEntry_DoNotUse_statedb_2eproto.base,
+  &scc_info_LoadProgramDBRequest_statedb_2eproto.base,
+  &scc_info_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_statedb_2eproto.base,
   &scc_info_ResultCode_statedb_2eproto.base,
   &scc_info_SetProgramRequest_statedb_2eproto.base,
   &scc_info_SetProgramResponse_statedb_2eproto.base,
   &scc_info_SetRequest_statedb_2eproto.base,
   &scc_info_SetResponse_statedb_2eproto.base,
+  &scc_info_SetResponse_DbReadLogEntry_DoNotUse_statedb_2eproto.base,
   &scc_info_SetResponse_SiblingsEntry_DoNotUse_statedb_2eproto.base,
   &scc_info_SiblingList_statedb_2eproto.base,
   &scc_info_Version_statedb_2eproto.base,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_statedb_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_statedb_2eproto = {
-  false, false, descriptor_table_protodef_statedb_2eproto, "statedb.proto", 2095,
-  &descriptor_table_statedb_2eproto_once, descriptor_table_statedb_2eproto_sccs, descriptor_table_statedb_2eproto_deps, 14, 1,
+  false, false, descriptor_table_protodef_statedb_2eproto, "statedb.proto", 2913,
+  &descriptor_table_statedb_2eproto_once, descriptor_table_statedb_2eproto_sccs, descriptor_table_statedb_2eproto_deps, 21, 1,
   schemas, file_default_instances, TableStruct_statedb_2eproto::offsets,
-  file_level_metadata_statedb_2eproto, 14, file_level_enum_descriptors_statedb_2eproto, file_level_service_descriptors_statedb_2eproto,
+  file_level_metadata_statedb_2eproto, 21, file_level_enum_descriptors_statedb_2eproto, file_level_service_descriptors_statedb_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -820,8 +1055,8 @@ SetRequest::SetRequest(const SetRequest& from)
     key_ = nullptr;
   }
   ::memcpy(&persistent_, &from.persistent_,
-    static_cast<size_t>(reinterpret_cast<char*>(&details_) -
-    reinterpret_cast<char*>(&persistent_)) + sizeof(details_));
+    static_cast<size_t>(reinterpret_cast<char*>(&get_db_read_log_) -
+    reinterpret_cast<char*>(&persistent_)) + sizeof(get_db_read_log_));
   // @@protoc_insertion_point(copy_constructor:statedb.v1.SetRequest)
 }
 
@@ -829,8 +1064,8 @@ void SetRequest::SharedCtor() {
   ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_SetRequest_statedb_2eproto.base);
   value_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   ::memset(&old_root_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&details_) -
-      reinterpret_cast<char*>(&old_root_)) + sizeof(details_));
+      reinterpret_cast<char*>(&get_db_read_log_) -
+      reinterpret_cast<char*>(&old_root_)) + sizeof(get_db_read_log_));
 }
 
 SetRequest::~SetRequest() {
@@ -877,8 +1112,8 @@ void SetRequest::Clear() {
   }
   key_ = nullptr;
   ::memset(&persistent_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&details_) -
-      reinterpret_cast<char*>(&persistent_)) + sizeof(details_));
+      reinterpret_cast<char*>(&get_db_read_log_) -
+      reinterpret_cast<char*>(&persistent_)) + sizeof(get_db_read_log_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -924,6 +1159,13 @@ const char* SetRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID:
       case 5:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 40)) {
           details_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool get_db_read_log = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 48)) {
+          get_db_read_log_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -993,6 +1235,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(5, this->_internal_details(), target);
   }
 
+  // bool get_db_read_log = 6;
+  if (this->get_db_read_log() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(6, this->_internal_get_db_read_log(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -1037,6 +1285,11 @@ size_t SetRequest::ByteSizeLong() const {
 
   // bool details = 5;
   if (this->details() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // bool get_db_read_log = 6;
+  if (this->get_db_read_log() != 0) {
     total_size += 1 + 1;
   }
 
@@ -1086,6 +1339,9 @@ void SetRequest::MergeFrom(const SetRequest& from) {
   if (from.details() != 0) {
     _internal_set_details(from._internal_details());
   }
+  if (from.get_db_read_log() != 0) {
+    _internal_set_get_db_read_log(from._internal_get_db_read_log());
+  }
 }
 
 void SetRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -1111,8 +1367,8 @@ void SetRequest::InternalSwap(SetRequest* other) {
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   value_.Swap(&other->value_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(SetRequest, details_)
-      + sizeof(SetRequest::details_)
+      PROTOBUF_FIELD_OFFSET(SetRequest, get_db_read_log_)
+      + sizeof(SetRequest::get_db_read_log_)
       - PROTOBUF_FIELD_OFFSET(SetRequest, old_root_)>(
           reinterpret_cast<char*>(&old_root_),
           reinterpret_cast<char*>(&other->old_root_));
@@ -1164,15 +1420,17 @@ GetRequest::GetRequest(const GetRequest& from)
   } else {
     key_ = nullptr;
   }
-  details_ = from.details_;
+  ::memcpy(&details_, &from.details_,
+    static_cast<size_t>(reinterpret_cast<char*>(&get_db_read_log_) -
+    reinterpret_cast<char*>(&details_)) + sizeof(get_db_read_log_));
   // @@protoc_insertion_point(copy_constructor:statedb.v1.GetRequest)
 }
 
 void GetRequest::SharedCtor() {
   ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_GetRequest_statedb_2eproto.base);
   ::memset(&root_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&details_) -
-      reinterpret_cast<char*>(&root_)) + sizeof(details_));
+      reinterpret_cast<char*>(&get_db_read_log_) -
+      reinterpret_cast<char*>(&root_)) + sizeof(get_db_read_log_));
 }
 
 GetRequest::~GetRequest() {
@@ -1216,7 +1474,9 @@ void GetRequest::Clear() {
     delete key_;
   }
   key_ = nullptr;
-  details_ = false;
+  ::memset(&details_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&get_db_read_log_) -
+      reinterpret_cast<char*>(&details_)) + sizeof(get_db_read_log_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -1246,6 +1506,13 @@ const char* GetRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID:
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
           details_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool get_db_read_log = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 32)) {
+          get_db_read_log_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -1299,6 +1566,12 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(3, this->_internal_details(), target);
   }
 
+  // bool get_db_read_log = 4;
+  if (this->get_db_read_log() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(4, this->_internal_get_db_read_log(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -1331,6 +1604,11 @@ size_t GetRequest::ByteSizeLong() const {
 
   // bool details = 3;
   if (this->details() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // bool get_db_read_log = 4;
+  if (this->get_db_read_log() != 0) {
     total_size += 1 + 1;
   }
 
@@ -1374,6 +1652,9 @@ void GetRequest::MergeFrom(const GetRequest& from) {
   if (from.details() != 0) {
     _internal_set_details(from._internal_details());
   }
+  if (from.get_db_read_log() != 0) {
+    _internal_set_get_db_read_log(from._internal_get_db_read_log());
+  }
 }
 
 void GetRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -1398,8 +1679,8 @@ void GetRequest::InternalSwap(GetRequest* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(GetRequest, details_)
-      + sizeof(GetRequest::details_)
+      PROTOBUF_FIELD_OFFSET(GetRequest, get_db_read_log_)
+      + sizeof(GetRequest::get_db_read_log_)
       - PROTOBUF_FIELD_OFFSET(GetRequest, root_)>(
           reinterpret_cast<char*>(&root_),
           reinterpret_cast<char*>(&other->root_));
@@ -1905,6 +2186,566 @@ void GetProgramRequest::InternalSwap(GetProgramRequest* other) {
 
 // ===================================================================
 
+LoadDBRequest_InputDbEntry_DoNotUse::LoadDBRequest_InputDbEntry_DoNotUse() {}
+LoadDBRequest_InputDbEntry_DoNotUse::LoadDBRequest_InputDbEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+    : SuperType(arena) {}
+void LoadDBRequest_InputDbEntry_DoNotUse::MergeFrom(const LoadDBRequest_InputDbEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::PROTOBUF_NAMESPACE_ID::Metadata LoadDBRequest_InputDbEntry_DoNotUse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+void LoadDBRequest_InputDbEntry_DoNotUse::MergeFrom(
+    const ::PROTOBUF_NAMESPACE_ID::Message& other) {
+  ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void LoadDBRequest::InitAsDefaultInstance() {
+}
+class LoadDBRequest::_Internal {
+ public:
+};
+
+LoadDBRequest::LoadDBRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  input_db_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:statedb.v1.LoadDBRequest)
+}
+LoadDBRequest::LoadDBRequest(const LoadDBRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  input_db_.MergeFrom(from.input_db_);
+  persistent_ = from.persistent_;
+  // @@protoc_insertion_point(copy_constructor:statedb.v1.LoadDBRequest)
+}
+
+void LoadDBRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_LoadDBRequest_statedb_2eproto.base);
+  persistent_ = false;
+}
+
+LoadDBRequest::~LoadDBRequest() {
+  // @@protoc_insertion_point(destructor:statedb.v1.LoadDBRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void LoadDBRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void LoadDBRequest::ArenaDtor(void* object) {
+  LoadDBRequest* _this = reinterpret_cast< LoadDBRequest* >(object);
+  (void)_this;
+}
+void LoadDBRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void LoadDBRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const LoadDBRequest& LoadDBRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_LoadDBRequest_statedb_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void LoadDBRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:statedb.v1.LoadDBRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  input_db_.Clear();
+  persistent_ = false;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* LoadDBRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // map<string, .statedb.v1.FeList> input_db = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(&input_db_, ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // bool persistent = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
+          persistent_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* LoadDBRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:statedb.v1.LoadDBRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // map<string, .statedb.v1.FeList> input_db = 1;
+  if (!this->_internal_input_db().empty()) {
+    typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::PROTOBUF_NAMESPACE_ID::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+          "statedb.v1.LoadDBRequest.InputDbEntry.key");
+      }
+    };
+
+    if (stream->IsSerializationDeterministic() &&
+        this->_internal_input_db().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->_internal_input_db().size()]);
+      typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::size_type size_type;
+      size_type n = 0;
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+          it = this->_internal_input_db().begin();
+          it != this->_internal_input_db().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      for (size_type i = 0; i < n; i++) {
+        target = LoadDBRequest_InputDbEntry_DoNotUse::Funcs::InternalSerialize(1, items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second, target, stream);
+        Utf8Check::Check(&(*items[static_cast<ptrdiff_t>(i)]));
+      }
+    } else {
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+          it = this->_internal_input_db().begin();
+          it != this->_internal_input_db().end(); ++it) {
+        target = LoadDBRequest_InputDbEntry_DoNotUse::Funcs::InternalSerialize(1, it->first, it->second, target, stream);
+        Utf8Check::Check(&(*it));
+      }
+    }
+  }
+
+  // bool persistent = 2;
+  if (this->persistent() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(2, this->_internal_persistent(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:statedb.v1.LoadDBRequest)
+  return target;
+}
+
+size_t LoadDBRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:statedb.v1.LoadDBRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // map<string, .statedb.v1.FeList> input_db = 1;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_input_db_size());
+  for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+      it = this->_internal_input_db().begin();
+      it != this->_internal_input_db().end(); ++it) {
+    total_size += LoadDBRequest_InputDbEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
+  }
+
+  // bool persistent = 2;
+  if (this->persistent() != 0) {
+    total_size += 1 + 1;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void LoadDBRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:statedb.v1.LoadDBRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const LoadDBRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<LoadDBRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:statedb.v1.LoadDBRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:statedb.v1.LoadDBRequest)
+    MergeFrom(*source);
+  }
+}
+
+void LoadDBRequest::MergeFrom(const LoadDBRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:statedb.v1.LoadDBRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  input_db_.MergeFrom(from.input_db_);
+  if (from.persistent() != 0) {
+    _internal_set_persistent(from._internal_persistent());
+  }
+}
+
+void LoadDBRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:statedb.v1.LoadDBRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void LoadDBRequest::CopyFrom(const LoadDBRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:statedb.v1.LoadDBRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool LoadDBRequest::IsInitialized() const {
+  return true;
+}
+
+void LoadDBRequest::InternalSwap(LoadDBRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  input_db_.Swap(&other->input_db_);
+  swap(persistent_, other->persistent_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata LoadDBRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse() {}
+LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+    : SuperType(arena) {}
+void LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::MergeFrom(const LoadProgramDBRequest_InputProgramDbEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::PROTOBUF_NAMESPACE_ID::Metadata LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+void LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::MergeFrom(
+    const ::PROTOBUF_NAMESPACE_ID::Message& other) {
+  ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void LoadProgramDBRequest::InitAsDefaultInstance() {
+}
+class LoadProgramDBRequest::_Internal {
+ public:
+};
+
+LoadProgramDBRequest::LoadProgramDBRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  input_program_db_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:statedb.v1.LoadProgramDBRequest)
+}
+LoadProgramDBRequest::LoadProgramDBRequest(const LoadProgramDBRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  input_program_db_.MergeFrom(from.input_program_db_);
+  persistent_ = from.persistent_;
+  // @@protoc_insertion_point(copy_constructor:statedb.v1.LoadProgramDBRequest)
+}
+
+void LoadProgramDBRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_LoadProgramDBRequest_statedb_2eproto.base);
+  persistent_ = false;
+}
+
+LoadProgramDBRequest::~LoadProgramDBRequest() {
+  // @@protoc_insertion_point(destructor:statedb.v1.LoadProgramDBRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void LoadProgramDBRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void LoadProgramDBRequest::ArenaDtor(void* object) {
+  LoadProgramDBRequest* _this = reinterpret_cast< LoadProgramDBRequest* >(object);
+  (void)_this;
+}
+void LoadProgramDBRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void LoadProgramDBRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const LoadProgramDBRequest& LoadProgramDBRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_LoadProgramDBRequest_statedb_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void LoadProgramDBRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:statedb.v1.LoadProgramDBRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  input_program_db_.Clear();
+  persistent_ = false;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* LoadProgramDBRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // map<string, bytes> input_program_db = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(&input_program_db_, ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // bool persistent = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
+          persistent_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* LoadProgramDBRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:statedb.v1.LoadProgramDBRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // map<string, bytes> input_program_db = 1;
+  if (!this->_internal_input_program_db().empty()) {
+    typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::PROTOBUF_NAMESPACE_ID::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+          "statedb.v1.LoadProgramDBRequest.InputProgramDbEntry.key");
+      }
+    };
+
+    if (stream->IsSerializationDeterministic() &&
+        this->_internal_input_program_db().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->_internal_input_program_db().size()]);
+      typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::size_type size_type;
+      size_type n = 0;
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_iterator
+          it = this->_internal_input_program_db().begin();
+          it != this->_internal_input_program_db().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      for (size_type i = 0; i < n; i++) {
+        target = LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::Funcs::InternalSerialize(1, items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second, target, stream);
+        Utf8Check::Check(&(*items[static_cast<ptrdiff_t>(i)]));
+      }
+    } else {
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_iterator
+          it = this->_internal_input_program_db().begin();
+          it != this->_internal_input_program_db().end(); ++it) {
+        target = LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::Funcs::InternalSerialize(1, it->first, it->second, target, stream);
+        Utf8Check::Check(&(*it));
+      }
+    }
+  }
+
+  // bool persistent = 2;
+  if (this->persistent() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(2, this->_internal_persistent(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:statedb.v1.LoadProgramDBRequest)
+  return target;
+}
+
+size_t LoadProgramDBRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:statedb.v1.LoadProgramDBRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // map<string, bytes> input_program_db = 1;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_input_program_db_size());
+  for (::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >::const_iterator
+      it = this->_internal_input_program_db().begin();
+      it != this->_internal_input_program_db().end(); ++it) {
+    total_size += LoadProgramDBRequest_InputProgramDbEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
+  }
+
+  // bool persistent = 2;
+  if (this->persistent() != 0) {
+    total_size += 1 + 1;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void LoadProgramDBRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:statedb.v1.LoadProgramDBRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const LoadProgramDBRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<LoadProgramDBRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:statedb.v1.LoadProgramDBRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:statedb.v1.LoadProgramDBRequest)
+    MergeFrom(*source);
+  }
+}
+
+void LoadProgramDBRequest::MergeFrom(const LoadProgramDBRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:statedb.v1.LoadProgramDBRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  input_program_db_.MergeFrom(from.input_program_db_);
+  if (from.persistent() != 0) {
+    _internal_set_persistent(from._internal_persistent());
+  }
+}
+
+void LoadProgramDBRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:statedb.v1.LoadProgramDBRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void LoadProgramDBRequest::CopyFrom(const LoadProgramDBRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:statedb.v1.LoadProgramDBRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool LoadProgramDBRequest::IsInitialized() const {
+  return true;
+}
+
+void LoadProgramDBRequest::InternalSwap(LoadProgramDBRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  input_program_db_.Swap(&other->input_program_db_);
+  swap(persistent_, other->persistent_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata LoadProgramDBRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 SetResponse_SiblingsEntry_DoNotUse::SetResponse_SiblingsEntry_DoNotUse() {}
 SetResponse_SiblingsEntry_DoNotUse::SetResponse_SiblingsEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
     : SuperType(arena) {}
@@ -1915,6 +2756,23 @@ void SetResponse_SiblingsEntry_DoNotUse::MergeFrom(const SetResponse_SiblingsEnt
   return GetMetadataStatic();
 }
 void SetResponse_SiblingsEntry_DoNotUse::MergeFrom(
+    const ::PROTOBUF_NAMESPACE_ID::Message& other) {
+  ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+SetResponse_DbReadLogEntry_DoNotUse::SetResponse_DbReadLogEntry_DoNotUse() {}
+SetResponse_DbReadLogEntry_DoNotUse::SetResponse_DbReadLogEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+    : SuperType(arena) {}
+void SetResponse_DbReadLogEntry_DoNotUse::MergeFrom(const SetResponse_DbReadLogEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::PROTOBUF_NAMESPACE_ID::Metadata SetResponse_DbReadLogEntry_DoNotUse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+void SetResponse_DbReadLogEntry_DoNotUse::MergeFrom(
     const ::PROTOBUF_NAMESPACE_ID::Message& other) {
   ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom(other);
 }
@@ -1965,7 +2823,8 @@ SetResponse::_Internal::result(const SetResponse* msg) {
 }
 SetResponse::SetResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena),
-  siblings_(arena) {
+  siblings_(arena),
+  db_read_log_(arena) {
   SharedCtor();
   RegisterArenaDtor(arena);
   // @@protoc_insertion_point(arena_constructor:statedb.v1.SetResponse)
@@ -1974,6 +2833,7 @@ SetResponse::SetResponse(const SetResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   siblings_.MergeFrom(from.siblings_);
+  db_read_log_.MergeFrom(from.db_read_log_);
   ins_value_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   if (!from._internal_ins_value().empty()) {
     ins_value_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from._internal_ins_value(),
@@ -2077,6 +2937,7 @@ void SetResponse::Clear() {
   (void) cached_has_bits;
 
   siblings_.Clear();
+  db_read_log_.Clear();
   ins_value_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   old_value_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   new_value_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
@@ -2205,9 +3066,21 @@ const char* SetResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
-      // .statedb.v1.ResultCode result = 12;
+      // map<string, .statedb.v1.FeList> db_read_log = 12;
       case 12:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 98)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(&db_read_log_, ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<98>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // .statedb.v1.ResultCode result = 13;
+      case 13:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 106)) {
           ptr = ctx->ParseMessage(_internal_mutable_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -2355,12 +3228,53 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(11, this->_internal_proof_hash_counter(), target);
   }
 
-  // .statedb.v1.ResultCode result = 12;
+  // map<string, .statedb.v1.FeList> db_read_log = 12;
+  if (!this->_internal_db_read_log().empty()) {
+    typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::PROTOBUF_NAMESPACE_ID::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+          "statedb.v1.SetResponse.DbReadLogEntry.key");
+      }
+    };
+
+    if (stream->IsSerializationDeterministic() &&
+        this->_internal_db_read_log().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->_internal_db_read_log().size()]);
+      typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::size_type size_type;
+      size_type n = 0;
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+          it = this->_internal_db_read_log().begin();
+          it != this->_internal_db_read_log().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      for (size_type i = 0; i < n; i++) {
+        target = SetResponse_DbReadLogEntry_DoNotUse::Funcs::InternalSerialize(12, items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second, target, stream);
+        Utf8Check::Check(&(*items[static_cast<ptrdiff_t>(i)]));
+      }
+    } else {
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+          it = this->_internal_db_read_log().begin();
+          it != this->_internal_db_read_log().end(); ++it) {
+        target = SetResponse_DbReadLogEntry_DoNotUse::Funcs::InternalSerialize(12, it->first, it->second, target, stream);
+        Utf8Check::Check(&(*it));
+      }
+    }
+  }
+
+  // .statedb.v1.ResultCode result = 13;
   if (this->has_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        12, _Internal::result(this), target, stream);
+        13, _Internal::result(this), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2386,6 +3300,15 @@ size_t SetResponse::ByteSizeLong() const {
       it = this->_internal_siblings().begin();
       it != this->_internal_siblings().end(); ++it) {
     total_size += SetResponse_SiblingsEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
+  }
+
+  // map<string, .statedb.v1.FeList> db_read_log = 12;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_db_read_log_size());
+  for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+      it = this->_internal_db_read_log().begin();
+      it != this->_internal_db_read_log().end(); ++it) {
+    total_size += SetResponse_DbReadLogEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
   }
 
   // string ins_value = 6;
@@ -2444,7 +3367,7 @@ size_t SetResponse::ByteSizeLong() const {
         *ins_key_);
   }
 
-  // .statedb.v1.ResultCode result = 12;
+  // .statedb.v1.ResultCode result = 13;
   if (this->has_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -2495,6 +3418,7 @@ void SetResponse::MergeFrom(const SetResponse& from) {
   (void) cached_has_bits;
 
   siblings_.MergeFrom(from.siblings_);
+  db_read_log_.MergeFrom(from.db_read_log_);
   if (from.ins_value().size() > 0) {
     _internal_set_ins_value(from._internal_ins_value());
   }
@@ -2552,6 +3476,7 @@ void SetResponse::InternalSwap(SetResponse* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   siblings_.Swap(&other->siblings_);
+  db_read_log_.Swap(&other->db_read_log_);
   ins_value_.Swap(&other->ins_value_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   old_value_.Swap(&other->old_value_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   new_value_.Swap(&other->new_value_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
@@ -2581,6 +3506,23 @@ void GetResponse_SiblingsEntry_DoNotUse::MergeFrom(const GetResponse_SiblingsEnt
   return GetMetadataStatic();
 }
 void GetResponse_SiblingsEntry_DoNotUse::MergeFrom(
+    const ::PROTOBUF_NAMESPACE_ID::Message& other) {
+  ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+GetResponse_DbReadLogEntry_DoNotUse::GetResponse_DbReadLogEntry_DoNotUse() {}
+GetResponse_DbReadLogEntry_DoNotUse::GetResponse_DbReadLogEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+    : SuperType(arena) {}
+void GetResponse_DbReadLogEntry_DoNotUse::MergeFrom(const GetResponse_DbReadLogEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::PROTOBUF_NAMESPACE_ID::Metadata GetResponse_DbReadLogEntry_DoNotUse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+void GetResponse_DbReadLogEntry_DoNotUse::MergeFrom(
     const ::PROTOBUF_NAMESPACE_ID::Message& other) {
   ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom(other);
 }
@@ -2624,7 +3566,8 @@ GetResponse::_Internal::result(const GetResponse* msg) {
 }
 GetResponse::GetResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena),
-  siblings_(arena) {
+  siblings_(arena),
+  db_read_log_(arena) {
   SharedCtor();
   RegisterArenaDtor(arena);
   // @@protoc_insertion_point(arena_constructor:statedb.v1.GetResponse)
@@ -2633,6 +3576,7 @@ GetResponse::GetResponse(const GetResponse& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   siblings_.MergeFrom(from.siblings_);
+  db_read_log_.MergeFrom(from.db_read_log_);
   ins_value_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   if (!from._internal_ins_value().empty()) {
     ins_value_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from._internal_ins_value(),
@@ -2716,6 +3660,7 @@ void GetResponse::Clear() {
   (void) cached_has_bits;
 
   siblings_.Clear();
+  db_read_log_.Clear();
   ins_value_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   value_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   if (GetArena() == nullptr && root_ != nullptr) {
@@ -2813,9 +3758,21 @@ const char* GetResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
-      // .statedb.v1.ResultCode result = 9;
+      // map<string, .statedb.v1.FeList> db_read_log = 9;
       case 9:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 74)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(&db_read_log_, ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<74>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // .statedb.v1.ResultCode result = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 82)) {
           ptr = ctx->ParseMessage(_internal_mutable_result(), ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -2935,12 +3892,53 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(8, this->_internal_proof_hash_counter(), target);
   }
 
-  // .statedb.v1.ResultCode result = 9;
+  // map<string, .statedb.v1.FeList> db_read_log = 9;
+  if (!this->_internal_db_read_log().empty()) {
+    typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::PROTOBUF_NAMESPACE_ID::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+          "statedb.v1.GetResponse.DbReadLogEntry.key");
+      }
+    };
+
+    if (stream->IsSerializationDeterministic() &&
+        this->_internal_db_read_log().size() > 1) {
+      ::std::unique_ptr<SortItem[]> items(
+          new SortItem[this->_internal_db_read_log().size()]);
+      typedef ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::size_type size_type;
+      size_type n = 0;
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+          it = this->_internal_db_read_log().begin();
+          it != this->_internal_db_read_log().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      for (size_type i = 0; i < n; i++) {
+        target = GetResponse_DbReadLogEntry_DoNotUse::Funcs::InternalSerialize(9, items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second, target, stream);
+        Utf8Check::Check(&(*items[static_cast<ptrdiff_t>(i)]));
+      }
+    } else {
+      for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+          it = this->_internal_db_read_log().begin();
+          it != this->_internal_db_read_log().end(); ++it) {
+        target = GetResponse_DbReadLogEntry_DoNotUse::Funcs::InternalSerialize(9, it->first, it->second, target, stream);
+        Utf8Check::Check(&(*it));
+      }
+    }
+  }
+
+  // .statedb.v1.ResultCode result = 10;
   if (this->has_result()) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
       InternalWriteMessage(
-        9, _Internal::result(this), target, stream);
+        10, _Internal::result(this), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2966,6 +3964,15 @@ size_t GetResponse::ByteSizeLong() const {
       it = this->_internal_siblings().begin();
       it != this->_internal_siblings().end(); ++it) {
     total_size += GetResponse_SiblingsEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
+  }
+
+  // map<string, .statedb.v1.FeList> db_read_log = 9;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(this->_internal_db_read_log_size());
+  for (::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >::const_iterator
+      it = this->_internal_db_read_log().begin();
+      it != this->_internal_db_read_log().end(); ++it) {
+    total_size += GetResponse_DbReadLogEntry_DoNotUse::Funcs::ByteSizeLong(it->first, it->second);
   }
 
   // string ins_value = 5;
@@ -3003,7 +4010,7 @@ size_t GetResponse::ByteSizeLong() const {
         *ins_key_);
   }
 
-  // .statedb.v1.ResultCode result = 9;
+  // .statedb.v1.ResultCode result = 10;
   if (this->has_result()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -3054,6 +4061,7 @@ void GetResponse::MergeFrom(const GetResponse& from) {
   (void) cached_has_bits;
 
   siblings_.MergeFrom(from.siblings_);
+  db_read_log_.MergeFrom(from.db_read_log_);
   if (from.ins_value().size() > 0) {
     _internal_set_ins_value(from._internal_ins_value());
   }
@@ -3102,6 +4110,7 @@ void GetResponse::InternalSwap(GetResponse* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   siblings_.Swap(&other->siblings_);
+  db_read_log_.Swap(&other->db_read_log_);
   ins_value_.Swap(&other->ins_value_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   value_.Swap(&other->value_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
@@ -3859,6 +4868,215 @@ void Fea::InternalSwap(Fea* other) {
 
 // ===================================================================
 
+void FeList::InitAsDefaultInstance() {
+}
+class FeList::_Internal {
+ public:
+};
+
+FeList::FeList(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  fe_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:statedb.v1.FeList)
+}
+FeList::FeList(const FeList& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      fe_(from.fe_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:statedb.v1.FeList)
+}
+
+void FeList::SharedCtor() {
+}
+
+FeList::~FeList() {
+  // @@protoc_insertion_point(destructor:statedb.v1.FeList)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void FeList::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void FeList::ArenaDtor(void* object) {
+  FeList* _this = reinterpret_cast< FeList* >(object);
+  (void)_this;
+}
+void FeList::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void FeList::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const FeList& FeList::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_FeList_statedb_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void FeList::Clear() {
+// @@protoc_insertion_point(message_clear_start:statedb.v1.FeList)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  fe_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* FeList::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // repeated uint64 fe = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::PackedUInt64Parser(_internal_mutable_fe(), ptr, ctx);
+          CHK_(ptr);
+        } else if (static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8) {
+          _internal_add_fe(::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* FeList::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:statedb.v1.FeList)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated uint64 fe = 1;
+  {
+    int byte_size = _fe_cached_byte_size_.load(std::memory_order_relaxed);
+    if (byte_size > 0) {
+      target = stream->WriteUInt64Packed(
+          1, _internal_fe(), byte_size, target);
+    }
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:statedb.v1.FeList)
+  return target;
+}
+
+size_t FeList::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:statedb.v1.FeList)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated uint64 fe = 1;
+  {
+    size_t data_size = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      UInt64Size(this->fe_);
+    if (data_size > 0) {
+      total_size += 1 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+            static_cast<::PROTOBUF_NAMESPACE_ID::int32>(data_size));
+    }
+    int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(data_size);
+    _fe_cached_byte_size_.store(cached_size,
+                                    std::memory_order_relaxed);
+    total_size += data_size;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void FeList::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:statedb.v1.FeList)
+  GOOGLE_DCHECK_NE(&from, this);
+  const FeList* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<FeList>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:statedb.v1.FeList)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:statedb.v1.FeList)
+    MergeFrom(*source);
+  }
+}
+
+void FeList::MergeFrom(const FeList& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:statedb.v1.FeList)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  fe_.MergeFrom(from.fe_);
+}
+
+void FeList::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:statedb.v1.FeList)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void FeList::CopyFrom(const FeList& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:statedb.v1.FeList)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool FeList::IsInitialized() const {
+  return true;
+}
+
+void FeList::InternalSwap(FeList* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  fe_.InternalSwap(&other->fe_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata FeList::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 void SiblingList::InitAsDefaultInstance() {
 }
 class SiblingList::_Internal {
@@ -4283,14 +5501,32 @@ template<> PROTOBUF_NOINLINE ::statedb::v1::SetProgramRequest* Arena::CreateMayb
 template<> PROTOBUF_NOINLINE ::statedb::v1::GetProgramRequest* Arena::CreateMaybeMessage< ::statedb::v1::GetProgramRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::GetProgramRequest >(arena);
 }
+template<> PROTOBUF_NOINLINE ::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse* Arena::CreateMaybeMessage< ::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::statedb::v1::LoadDBRequest* Arena::CreateMaybeMessage< ::statedb::v1::LoadDBRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::LoadDBRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse* Arena::CreateMaybeMessage< ::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::statedb::v1::LoadProgramDBRequest* Arena::CreateMaybeMessage< ::statedb::v1::LoadProgramDBRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::LoadProgramDBRequest >(arena);
+}
 template<> PROTOBUF_NOINLINE ::statedb::v1::SetResponse_SiblingsEntry_DoNotUse* Arena::CreateMaybeMessage< ::statedb::v1::SetResponse_SiblingsEntry_DoNotUse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::SetResponse_SiblingsEntry_DoNotUse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse* Arena::CreateMaybeMessage< ::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::statedb::v1::SetResponse* Arena::CreateMaybeMessage< ::statedb::v1::SetResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::SetResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::statedb::v1::GetResponse_SiblingsEntry_DoNotUse* Arena::CreateMaybeMessage< ::statedb::v1::GetResponse_SiblingsEntry_DoNotUse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::GetResponse_SiblingsEntry_DoNotUse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse* Arena::CreateMaybeMessage< ::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::statedb::v1::GetResponse* Arena::CreateMaybeMessage< ::statedb::v1::GetResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::GetResponse >(arena);
@@ -4303,6 +5539,9 @@ template<> PROTOBUF_NOINLINE ::statedb::v1::GetProgramResponse* Arena::CreateMay
 }
 template<> PROTOBUF_NOINLINE ::statedb::v1::Fea* Arena::CreateMaybeMessage< ::statedb::v1::Fea >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::Fea >(arena);
+}
+template<> PROTOBUF_NOINLINE ::statedb::v1::FeList* Arena::CreateMaybeMessage< ::statedb::v1::FeList >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::statedb::v1::FeList >(arena);
 }
 template<> PROTOBUF_NOINLINE ::statedb::v1::SiblingList* Arena::CreateMaybeMessage< ::statedb::v1::SiblingList >(Arena* arena) {
   return Arena::CreateMessageInternal< ::statedb::v1::SiblingList >(arena);

--- a/src/grpc/gen/statedb.pb.h
+++ b/src/grpc/gen/statedb.pb.h
@@ -52,7 +52,7 @@ struct TableStruct_statedb_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxillaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[14]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[21]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -61,6 +61,9 @@ struct TableStruct_statedb_2eproto {
 extern const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_statedb_2eproto;
 namespace statedb {
 namespace v1 {
+class FeList;
+class FeListDefaultTypeInternal;
+extern FeListDefaultTypeInternal _FeList_default_instance_;
 class Fea;
 class FeaDefaultTypeInternal;
 extern FeaDefaultTypeInternal _Fea_default_instance_;
@@ -76,9 +79,24 @@ extern GetRequestDefaultTypeInternal _GetRequest_default_instance_;
 class GetResponse;
 class GetResponseDefaultTypeInternal;
 extern GetResponseDefaultTypeInternal _GetResponse_default_instance_;
+class GetResponse_DbReadLogEntry_DoNotUse;
+class GetResponse_DbReadLogEntry_DoNotUseDefaultTypeInternal;
+extern GetResponse_DbReadLogEntry_DoNotUseDefaultTypeInternal _GetResponse_DbReadLogEntry_DoNotUse_default_instance_;
 class GetResponse_SiblingsEntry_DoNotUse;
 class GetResponse_SiblingsEntry_DoNotUseDefaultTypeInternal;
 extern GetResponse_SiblingsEntry_DoNotUseDefaultTypeInternal _GetResponse_SiblingsEntry_DoNotUse_default_instance_;
+class LoadDBRequest;
+class LoadDBRequestDefaultTypeInternal;
+extern LoadDBRequestDefaultTypeInternal _LoadDBRequest_default_instance_;
+class LoadDBRequest_InputDbEntry_DoNotUse;
+class LoadDBRequest_InputDbEntry_DoNotUseDefaultTypeInternal;
+extern LoadDBRequest_InputDbEntry_DoNotUseDefaultTypeInternal _LoadDBRequest_InputDbEntry_DoNotUse_default_instance_;
+class LoadProgramDBRequest;
+class LoadProgramDBRequestDefaultTypeInternal;
+extern LoadProgramDBRequestDefaultTypeInternal _LoadProgramDBRequest_default_instance_;
+class LoadProgramDBRequest_InputProgramDbEntry_DoNotUse;
+class LoadProgramDBRequest_InputProgramDbEntry_DoNotUseDefaultTypeInternal;
+extern LoadProgramDBRequest_InputProgramDbEntry_DoNotUseDefaultTypeInternal _LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_default_instance_;
 class ResultCode;
 class ResultCodeDefaultTypeInternal;
 extern ResultCodeDefaultTypeInternal _ResultCode_default_instance_;
@@ -94,6 +112,9 @@ extern SetRequestDefaultTypeInternal _SetRequest_default_instance_;
 class SetResponse;
 class SetResponseDefaultTypeInternal;
 extern SetResponseDefaultTypeInternal _SetResponse_default_instance_;
+class SetResponse_DbReadLogEntry_DoNotUse;
+class SetResponse_DbReadLogEntry_DoNotUseDefaultTypeInternal;
+extern SetResponse_DbReadLogEntry_DoNotUseDefaultTypeInternal _SetResponse_DbReadLogEntry_DoNotUse_default_instance_;
 class SetResponse_SiblingsEntry_DoNotUse;
 class SetResponse_SiblingsEntry_DoNotUseDefaultTypeInternal;
 extern SetResponse_SiblingsEntry_DoNotUseDefaultTypeInternal _SetResponse_SiblingsEntry_DoNotUse_default_instance_;
@@ -106,17 +127,24 @@ extern VersionDefaultTypeInternal _Version_default_instance_;
 }  // namespace v1
 }  // namespace statedb
 PROTOBUF_NAMESPACE_OPEN
+template<> ::statedb::v1::FeList* Arena::CreateMaybeMessage<::statedb::v1::FeList>(Arena*);
 template<> ::statedb::v1::Fea* Arena::CreateMaybeMessage<::statedb::v1::Fea>(Arena*);
 template<> ::statedb::v1::GetProgramRequest* Arena::CreateMaybeMessage<::statedb::v1::GetProgramRequest>(Arena*);
 template<> ::statedb::v1::GetProgramResponse* Arena::CreateMaybeMessage<::statedb::v1::GetProgramResponse>(Arena*);
 template<> ::statedb::v1::GetRequest* Arena::CreateMaybeMessage<::statedb::v1::GetRequest>(Arena*);
 template<> ::statedb::v1::GetResponse* Arena::CreateMaybeMessage<::statedb::v1::GetResponse>(Arena*);
+template<> ::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse* Arena::CreateMaybeMessage<::statedb::v1::GetResponse_DbReadLogEntry_DoNotUse>(Arena*);
 template<> ::statedb::v1::GetResponse_SiblingsEntry_DoNotUse* Arena::CreateMaybeMessage<::statedb::v1::GetResponse_SiblingsEntry_DoNotUse>(Arena*);
+template<> ::statedb::v1::LoadDBRequest* Arena::CreateMaybeMessage<::statedb::v1::LoadDBRequest>(Arena*);
+template<> ::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse* Arena::CreateMaybeMessage<::statedb::v1::LoadDBRequest_InputDbEntry_DoNotUse>(Arena*);
+template<> ::statedb::v1::LoadProgramDBRequest* Arena::CreateMaybeMessage<::statedb::v1::LoadProgramDBRequest>(Arena*);
+template<> ::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse* Arena::CreateMaybeMessage<::statedb::v1::LoadProgramDBRequest_InputProgramDbEntry_DoNotUse>(Arena*);
 template<> ::statedb::v1::ResultCode* Arena::CreateMaybeMessage<::statedb::v1::ResultCode>(Arena*);
 template<> ::statedb::v1::SetProgramRequest* Arena::CreateMaybeMessage<::statedb::v1::SetProgramRequest>(Arena*);
 template<> ::statedb::v1::SetProgramResponse* Arena::CreateMaybeMessage<::statedb::v1::SetProgramResponse>(Arena*);
 template<> ::statedb::v1::SetRequest* Arena::CreateMaybeMessage<::statedb::v1::SetRequest>(Arena*);
 template<> ::statedb::v1::SetResponse* Arena::CreateMaybeMessage<::statedb::v1::SetResponse>(Arena*);
+template<> ::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse* Arena::CreateMaybeMessage<::statedb::v1::SetResponse_DbReadLogEntry_DoNotUse>(Arena*);
 template<> ::statedb::v1::SetResponse_SiblingsEntry_DoNotUse* Arena::CreateMaybeMessage<::statedb::v1::SetResponse_SiblingsEntry_DoNotUse>(Arena*);
 template<> ::statedb::v1::SiblingList* Arena::CreateMaybeMessage<::statedb::v1::SiblingList>(Arena*);
 template<> ::statedb::v1::Version* Arena::CreateMaybeMessage<::statedb::v1::Version>(Arena*);
@@ -426,6 +454,7 @@ class SetRequest PROTOBUF_FINAL :
     kKeyFieldNumber = 2,
     kPersistentFieldNumber = 4,
     kDetailsFieldNumber = 5,
+    kGetDbReadLogFieldNumber = 6,
   };
   // string value = 3;
   void clear_value();
@@ -506,6 +535,15 @@ class SetRequest PROTOBUF_FINAL :
   void _internal_set_details(bool value);
   public:
 
+  // bool get_db_read_log = 6;
+  void clear_get_db_read_log();
+  bool get_db_read_log() const;
+  void set_get_db_read_log(bool value);
+  private:
+  bool _internal_get_db_read_log() const;
+  void _internal_set_get_db_read_log(bool value);
+  public:
+
   // @@protoc_insertion_point(class_scope:statedb.v1.SetRequest)
  private:
   class _Internal;
@@ -518,6 +556,7 @@ class SetRequest PROTOBUF_FINAL :
   ::statedb::v1::Fea* key_;
   bool persistent_;
   bool details_;
+  bool get_db_read_log_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_statedb_2eproto;
 };
@@ -639,6 +678,7 @@ class GetRequest PROTOBUF_FINAL :
     kRootFieldNumber = 1,
     kKeyFieldNumber = 2,
     kDetailsFieldNumber = 3,
+    kGetDbReadLogFieldNumber = 4,
   };
   // .statedb.v1.Fea root = 1;
   bool has_root() const;
@@ -685,6 +725,15 @@ class GetRequest PROTOBUF_FINAL :
   void _internal_set_details(bool value);
   public:
 
+  // bool get_db_read_log = 4;
+  void clear_get_db_read_log();
+  bool get_db_read_log() const;
+  void set_get_db_read_log(bool value);
+  private:
+  bool _internal_get_db_read_log() const;
+  void _internal_set_get_db_read_log(bool value);
+  public:
+
   // @@protoc_insertion_point(class_scope:statedb.v1.GetRequest)
  private:
   class _Internal;
@@ -695,6 +744,7 @@ class GetRequest PROTOBUF_FINAL :
   ::statedb::v1::Fea* root_;
   ::statedb::v1::Fea* key_;
   bool details_;
+  bool get_db_read_log_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_statedb_2eproto;
 };
@@ -1030,6 +1080,394 @@ class GetProgramRequest PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class LoadDBRequest_InputDbEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<LoadDBRequest_InputDbEntry_DoNotUse, 
+    std::string, ::statedb::v1::FeList,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > {
+public:
+  typedef ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<LoadDBRequest_InputDbEntry_DoNotUse, 
+    std::string, ::statedb::v1::FeList,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > SuperType;
+  LoadDBRequest_InputDbEntry_DoNotUse();
+  LoadDBRequest_InputDbEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  void MergeFrom(const LoadDBRequest_InputDbEntry_DoNotUse& other);
+  static const LoadDBRequest_InputDbEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const LoadDBRequest_InputDbEntry_DoNotUse*>(&_LoadDBRequest_InputDbEntry_DoNotUse_default_instance_); }
+  static bool ValidateKey(std::string* s) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(s->data(), static_cast<int>(s->size()), ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::PARSE, "statedb.v1.LoadDBRequest.InputDbEntry.key");
+ }
+  static bool ValidateValue(void*) { return true; }
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& other) final;
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[5];
+  }
+
+  public:
+};
+
+// -------------------------------------------------------------------
+
+class LoadDBRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:statedb.v1.LoadDBRequest) */ {
+ public:
+  inline LoadDBRequest() : LoadDBRequest(nullptr) {};
+  virtual ~LoadDBRequest();
+
+  LoadDBRequest(const LoadDBRequest& from);
+  LoadDBRequest(LoadDBRequest&& from) noexcept
+    : LoadDBRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline LoadDBRequest& operator=(const LoadDBRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline LoadDBRequest& operator=(LoadDBRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const LoadDBRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const LoadDBRequest* internal_default_instance() {
+    return reinterpret_cast<const LoadDBRequest*>(
+               &_LoadDBRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    6;
+
+  friend void swap(LoadDBRequest& a, LoadDBRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(LoadDBRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(LoadDBRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline LoadDBRequest* New() const final {
+    return CreateMaybeMessage<LoadDBRequest>(nullptr);
+  }
+
+  LoadDBRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<LoadDBRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const LoadDBRequest& from);
+  void MergeFrom(const LoadDBRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(LoadDBRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "statedb.v1.LoadDBRequest";
+  }
+  protected:
+  explicit LoadDBRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kInputDbFieldNumber = 1,
+    kPersistentFieldNumber = 2,
+  };
+  // map<string, .statedb.v1.FeList> input_db = 1;
+  int input_db_size() const;
+  private:
+  int _internal_input_db_size() const;
+  public:
+  void clear_input_db();
+  private:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+      _internal_input_db() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+      _internal_mutable_input_db();
+  public:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+      input_db() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+      mutable_input_db();
+
+  // bool persistent = 2;
+  void clear_persistent();
+  bool persistent() const;
+  void set_persistent(bool value);
+  private:
+  bool _internal_persistent() const;
+  void _internal_set_persistent(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:statedb.v1.LoadDBRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::MapField<
+      LoadDBRequest_InputDbEntry_DoNotUse,
+      std::string, ::statedb::v1::FeList,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+      0 > input_db_;
+  bool persistent_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_statedb_2eproto;
+};
+// -------------------------------------------------------------------
+
+class LoadProgramDBRequest_InputProgramDbEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<LoadProgramDBRequest_InputProgramDbEntry_DoNotUse, 
+    std::string, std::string,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_BYTES,
+    0 > {
+public:
+  typedef ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<LoadProgramDBRequest_InputProgramDbEntry_DoNotUse, 
+    std::string, std::string,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_BYTES,
+    0 > SuperType;
+  LoadProgramDBRequest_InputProgramDbEntry_DoNotUse();
+  LoadProgramDBRequest_InputProgramDbEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  void MergeFrom(const LoadProgramDBRequest_InputProgramDbEntry_DoNotUse& other);
+  static const LoadProgramDBRequest_InputProgramDbEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const LoadProgramDBRequest_InputProgramDbEntry_DoNotUse*>(&_LoadProgramDBRequest_InputProgramDbEntry_DoNotUse_default_instance_); }
+  static bool ValidateKey(std::string* s) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(s->data(), static_cast<int>(s->size()), ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::PARSE, "statedb.v1.LoadProgramDBRequest.InputProgramDbEntry.key");
+ }
+  static bool ValidateValue(void*) { return true; }
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& other) final;
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[7];
+  }
+
+  public:
+};
+
+// -------------------------------------------------------------------
+
+class LoadProgramDBRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:statedb.v1.LoadProgramDBRequest) */ {
+ public:
+  inline LoadProgramDBRequest() : LoadProgramDBRequest(nullptr) {};
+  virtual ~LoadProgramDBRequest();
+
+  LoadProgramDBRequest(const LoadProgramDBRequest& from);
+  LoadProgramDBRequest(LoadProgramDBRequest&& from) noexcept
+    : LoadProgramDBRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline LoadProgramDBRequest& operator=(const LoadProgramDBRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline LoadProgramDBRequest& operator=(LoadProgramDBRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const LoadProgramDBRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const LoadProgramDBRequest* internal_default_instance() {
+    return reinterpret_cast<const LoadProgramDBRequest*>(
+               &_LoadProgramDBRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  friend void swap(LoadProgramDBRequest& a, LoadProgramDBRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(LoadProgramDBRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(LoadProgramDBRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline LoadProgramDBRequest* New() const final {
+    return CreateMaybeMessage<LoadProgramDBRequest>(nullptr);
+  }
+
+  LoadProgramDBRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<LoadProgramDBRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const LoadProgramDBRequest& from);
+  void MergeFrom(const LoadProgramDBRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(LoadProgramDBRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "statedb.v1.LoadProgramDBRequest";
+  }
+  protected:
+  explicit LoadProgramDBRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kInputProgramDbFieldNumber = 1,
+    kPersistentFieldNumber = 2,
+  };
+  // map<string, bytes> input_program_db = 1;
+  int input_program_db_size() const;
+  private:
+  int _internal_input_program_db_size() const;
+  public:
+  void clear_input_program_db();
+  private:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+      _internal_input_program_db() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+      _internal_mutable_input_program_db();
+  public:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+      input_program_db() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+      mutable_input_program_db();
+
+  // bool persistent = 2;
+  void clear_persistent();
+  bool persistent() const;
+  void set_persistent(bool value);
+  private:
+  bool _internal_persistent() const;
+  void _internal_set_persistent(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:statedb.v1.LoadProgramDBRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::MapField<
+      LoadProgramDBRequest_InputProgramDbEntry_DoNotUse,
+      std::string, std::string,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_BYTES,
+      0 > input_program_db_;
+  bool persistent_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_statedb_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetResponse_SiblingsEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<SetResponse_SiblingsEntry_DoNotUse, 
     ::PROTOBUF_NAMESPACE_ID::uint64, ::statedb::v1::SiblingList,
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_UINT64,
@@ -1052,7 +1490,39 @@ public:
   private:
   static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
     ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
-    return ::descriptor_table_statedb_2eproto.file_level_metadata[5];
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[9];
+  }
+
+  public:
+};
+
+// -------------------------------------------------------------------
+
+class SetResponse_DbReadLogEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<SetResponse_DbReadLogEntry_DoNotUse, 
+    std::string, ::statedb::v1::FeList,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > {
+public:
+  typedef ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<SetResponse_DbReadLogEntry_DoNotUse, 
+    std::string, ::statedb::v1::FeList,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > SuperType;
+  SetResponse_DbReadLogEntry_DoNotUse();
+  SetResponse_DbReadLogEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  void MergeFrom(const SetResponse_DbReadLogEntry_DoNotUse& other);
+  static const SetResponse_DbReadLogEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const SetResponse_DbReadLogEntry_DoNotUse*>(&_SetResponse_DbReadLogEntry_DoNotUse_default_instance_); }
+  static bool ValidateKey(std::string* s) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(s->data(), static_cast<int>(s->size()), ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::PARSE, "statedb.v1.SetResponse.DbReadLogEntry.key");
+ }
+  static bool ValidateValue(void*) { return true; }
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& other) final;
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[10];
   }
 
   public:
@@ -1102,7 +1572,7 @@ class SetResponse PROTOBUF_FINAL :
                &_SetResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    6;
+    11;
 
   friend void swap(SetResponse& a, SetResponse& b) {
     a.Swap(&b);
@@ -1175,6 +1645,7 @@ class SetResponse PROTOBUF_FINAL :
 
   enum : int {
     kSiblingsFieldNumber = 4,
+    kDbReadLogFieldNumber = 12,
     kInsValueFieldNumber = 6,
     kOldValueFieldNumber = 8,
     kNewValueFieldNumber = 9,
@@ -1183,7 +1654,7 @@ class SetResponse PROTOBUF_FINAL :
     kNewRootFieldNumber = 2,
     kKeyFieldNumber = 3,
     kInsKeyFieldNumber = 5,
-    kResultFieldNumber = 12,
+    kResultFieldNumber = 13,
     kProofHashCounterFieldNumber = 11,
     kIsOld0FieldNumber = 7,
   };
@@ -1203,6 +1674,23 @@ class SetResponse PROTOBUF_FINAL :
       siblings() const;
   ::PROTOBUF_NAMESPACE_ID::Map< ::PROTOBUF_NAMESPACE_ID::uint64, ::statedb::v1::SiblingList >*
       mutable_siblings();
+
+  // map<string, .statedb.v1.FeList> db_read_log = 12;
+  int db_read_log_size() const;
+  private:
+  int _internal_db_read_log_size() const;
+  public:
+  void clear_db_read_log();
+  private:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+      _internal_db_read_log() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+      _internal_mutable_db_read_log();
+  public:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+      db_read_log() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+      mutable_db_read_log();
 
   // string ins_value = 6;
   void clear_ins_value();
@@ -1376,7 +1864,7 @@ class SetResponse PROTOBUF_FINAL :
       ::statedb::v1::Fea* ins_key);
   ::statedb::v1::Fea* unsafe_arena_release_ins_key();
 
-  // .statedb.v1.ResultCode result = 12;
+  // .statedb.v1.ResultCode result = 13;
   bool has_result() const;
   private:
   bool _internal_has_result() const;
@@ -1425,6 +1913,12 @@ class SetResponse PROTOBUF_FINAL :
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_UINT64,
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
       0 > siblings_;
+  ::PROTOBUF_NAMESPACE_ID::internal::MapField<
+      SetResponse_DbReadLogEntry_DoNotUse,
+      std::string, ::statedb::v1::FeList,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+      0 > db_read_log_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr ins_value_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr old_value_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr new_value_;
@@ -1463,7 +1957,39 @@ public:
   private:
   static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
     ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
-    return ::descriptor_table_statedb_2eproto.file_level_metadata[7];
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[12];
+  }
+
+  public:
+};
+
+// -------------------------------------------------------------------
+
+class GetResponse_DbReadLogEntry_DoNotUse : public ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<GetResponse_DbReadLogEntry_DoNotUse, 
+    std::string, ::statedb::v1::FeList,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > {
+public:
+  typedef ::PROTOBUF_NAMESPACE_ID::internal::MapEntry<GetResponse_DbReadLogEntry_DoNotUse, 
+    std::string, ::statedb::v1::FeList,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+    0 > SuperType;
+  GetResponse_DbReadLogEntry_DoNotUse();
+  GetResponse_DbReadLogEntry_DoNotUse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  void MergeFrom(const GetResponse_DbReadLogEntry_DoNotUse& other);
+  static const GetResponse_DbReadLogEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GetResponse_DbReadLogEntry_DoNotUse*>(&_GetResponse_DbReadLogEntry_DoNotUse_default_instance_); }
+  static bool ValidateKey(std::string* s) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(s->data(), static_cast<int>(s->size()), ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::PARSE, "statedb.v1.GetResponse.DbReadLogEntry.key");
+ }
+  static bool ValidateValue(void*) { return true; }
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& other) final;
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[13];
   }
 
   public:
@@ -1513,7 +2039,7 @@ class GetResponse PROTOBUF_FINAL :
                &_GetResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    14;
 
   friend void swap(GetResponse& a, GetResponse& b) {
     a.Swap(&b);
@@ -1586,12 +2112,13 @@ class GetResponse PROTOBUF_FINAL :
 
   enum : int {
     kSiblingsFieldNumber = 3,
+    kDbReadLogFieldNumber = 9,
     kInsValueFieldNumber = 5,
     kValueFieldNumber = 7,
     kRootFieldNumber = 1,
     kKeyFieldNumber = 2,
     kInsKeyFieldNumber = 4,
-    kResultFieldNumber = 9,
+    kResultFieldNumber = 10,
     kProofHashCounterFieldNumber = 8,
     kIsOld0FieldNumber = 6,
   };
@@ -1611,6 +2138,23 @@ class GetResponse PROTOBUF_FINAL :
       siblings() const;
   ::PROTOBUF_NAMESPACE_ID::Map< ::PROTOBUF_NAMESPACE_ID::uint64, ::statedb::v1::SiblingList >*
       mutable_siblings();
+
+  // map<string, .statedb.v1.FeList> db_read_log = 9;
+  int db_read_log_size() const;
+  private:
+  int _internal_db_read_log_size() const;
+  public:
+  void clear_db_read_log();
+  private:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+      _internal_db_read_log() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+      _internal_mutable_db_read_log();
+  public:
+  const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+      db_read_log() const;
+  ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+      mutable_db_read_log();
 
   // string ins_value = 5;
   void clear_ins_value();
@@ -1716,7 +2260,7 @@ class GetResponse PROTOBUF_FINAL :
       ::statedb::v1::Fea* ins_key);
   ::statedb::v1::Fea* unsafe_arena_release_ins_key();
 
-  // .statedb.v1.ResultCode result = 9;
+  // .statedb.v1.ResultCode result = 10;
   bool has_result() const;
   private:
   bool _internal_has_result() const;
@@ -1765,6 +2309,12 @@ class GetResponse PROTOBUF_FINAL :
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_UINT64,
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
       0 > siblings_;
+  ::PROTOBUF_NAMESPACE_ID::internal::MapField<
+      GetResponse_DbReadLogEntry_DoNotUse,
+      std::string, ::statedb::v1::FeList,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_STRING,
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::TYPE_MESSAGE,
+      0 > db_read_log_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr ins_value_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr value_;
   ::statedb::v1::Fea* root_;
@@ -1820,7 +2370,7 @@ class SetProgramResponse PROTOBUF_FINAL :
                &_SetProgramResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    15;
 
   friend void swap(SetProgramResponse& a, SetProgramResponse& b) {
     a.Swap(&b);
@@ -1966,7 +2516,7 @@ class GetProgramResponse PROTOBUF_FINAL :
                &_GetProgramResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    16;
 
   friend void swap(GetProgramResponse& a, GetProgramResponse& b) {
     a.Swap(&b);
@@ -2139,7 +2689,7 @@ class Fea PROTOBUF_FINAL :
                &_Fea_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    17;
 
   friend void swap(Fea& a, Fea& b) {
     a.Swap(&b);
@@ -2267,6 +2817,157 @@ class Fea PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class FeList PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:statedb.v1.FeList) */ {
+ public:
+  inline FeList() : FeList(nullptr) {};
+  virtual ~FeList();
+
+  FeList(const FeList& from);
+  FeList(FeList&& from) noexcept
+    : FeList() {
+    *this = ::std::move(from);
+  }
+
+  inline FeList& operator=(const FeList& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FeList& operator=(FeList&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const FeList& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const FeList* internal_default_instance() {
+    return reinterpret_cast<const FeList*>(
+               &_FeList_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    18;
+
+  friend void swap(FeList& a, FeList& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(FeList* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FeList* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline FeList* New() const final {
+    return CreateMaybeMessage<FeList>(nullptr);
+  }
+
+  FeList* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<FeList>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const FeList& from);
+  void MergeFrom(const FeList& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(FeList* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "statedb.v1.FeList";
+  }
+  protected:
+  explicit FeList(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_statedb_2eproto);
+    return ::descriptor_table_statedb_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kFeFieldNumber = 1,
+  };
+  // repeated uint64 fe = 1;
+  int fe_size() const;
+  private:
+  int _internal_fe_size() const;
+  public:
+  void clear_fe();
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_fe(int index) const;
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >&
+      _internal_fe() const;
+  void _internal_add_fe(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >*
+      _internal_mutable_fe();
+  public:
+  ::PROTOBUF_NAMESPACE_ID::uint64 fe(int index) const;
+  void set_fe(int index, ::PROTOBUF_NAMESPACE_ID::uint64 value);
+  void add_fe(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >&
+      fe() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >*
+      mutable_fe();
+
+  // @@protoc_insertion_point(class_scope:statedb.v1.FeList)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 > fe_;
+  mutable std::atomic<int> _fe_cached_byte_size_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_statedb_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SiblingList PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:statedb.v1.SiblingList) */ {
  public:
@@ -2309,7 +3010,7 @@ class SiblingList PROTOBUF_FINAL :
                &_SiblingList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    19;
 
   friend void swap(SiblingList& a, SiblingList& b) {
     a.Swap(&b);
@@ -2460,7 +3161,7 @@ class ResultCode PROTOBUF_FINAL :
                &_ResultCode_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    20;
 
   friend void swap(ResultCode& a, ResultCode& b) {
     a.Swap(&b);
@@ -2970,6 +3671,26 @@ inline void SetRequest::set_details(bool value) {
   // @@protoc_insertion_point(field_set:statedb.v1.SetRequest.details)
 }
 
+// bool get_db_read_log = 6;
+inline void SetRequest::clear_get_db_read_log() {
+  get_db_read_log_ = false;
+}
+inline bool SetRequest::_internal_get_db_read_log() const {
+  return get_db_read_log_;
+}
+inline bool SetRequest::get_db_read_log() const {
+  // @@protoc_insertion_point(field_get:statedb.v1.SetRequest.get_db_read_log)
+  return _internal_get_db_read_log();
+}
+inline void SetRequest::_internal_set_get_db_read_log(bool value) {
+  
+  get_db_read_log_ = value;
+}
+inline void SetRequest::set_get_db_read_log(bool value) {
+  _internal_set_get_db_read_log(value);
+  // @@protoc_insertion_point(field_set:statedb.v1.SetRequest.get_db_read_log)
+}
+
 // -------------------------------------------------------------------
 
 // GetRequest
@@ -3154,6 +3875,26 @@ inline void GetRequest::_internal_set_details(bool value) {
 inline void GetRequest::set_details(bool value) {
   _internal_set_details(value);
   // @@protoc_insertion_point(field_set:statedb.v1.GetRequest.details)
+}
+
+// bool get_db_read_log = 4;
+inline void GetRequest::clear_get_db_read_log() {
+  get_db_read_log_ = false;
+}
+inline bool GetRequest::_internal_get_db_read_log() const {
+  return get_db_read_log_;
+}
+inline bool GetRequest::get_db_read_log() const {
+  // @@protoc_insertion_point(field_get:statedb.v1.GetRequest.get_db_read_log)
+  return _internal_get_db_read_log();
+}
+inline void GetRequest::_internal_set_get_db_read_log(bool value) {
+  
+  get_db_read_log_ = value;
+}
+inline void GetRequest::set_get_db_read_log(bool value) {
+  _internal_set_get_db_read_log(value);
+  // @@protoc_insertion_point(field_set:statedb.v1.GetRequest.get_db_read_log)
 }
 
 // -------------------------------------------------------------------
@@ -3426,6 +4167,118 @@ inline void GetProgramRequest::set_allocated_key(::statedb::v1::Fea* key) {
   key_ = key;
   // @@protoc_insertion_point(field_set_allocated:statedb.v1.GetProgramRequest.key)
 }
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// LoadDBRequest
+
+// map<string, .statedb.v1.FeList> input_db = 1;
+inline int LoadDBRequest::_internal_input_db_size() const {
+  return input_db_.size();
+}
+inline int LoadDBRequest::input_db_size() const {
+  return _internal_input_db_size();
+}
+inline void LoadDBRequest::clear_input_db() {
+  input_db_.Clear();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+LoadDBRequest::_internal_input_db() const {
+  return input_db_.GetMap();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+LoadDBRequest::input_db() const {
+  // @@protoc_insertion_point(field_map:statedb.v1.LoadDBRequest.input_db)
+  return _internal_input_db();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+LoadDBRequest::_internal_mutable_input_db() {
+  return input_db_.MutableMap();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+LoadDBRequest::mutable_input_db() {
+  // @@protoc_insertion_point(field_mutable_map:statedb.v1.LoadDBRequest.input_db)
+  return _internal_mutable_input_db();
+}
+
+// bool persistent = 2;
+inline void LoadDBRequest::clear_persistent() {
+  persistent_ = false;
+}
+inline bool LoadDBRequest::_internal_persistent() const {
+  return persistent_;
+}
+inline bool LoadDBRequest::persistent() const {
+  // @@protoc_insertion_point(field_get:statedb.v1.LoadDBRequest.persistent)
+  return _internal_persistent();
+}
+inline void LoadDBRequest::_internal_set_persistent(bool value) {
+  
+  persistent_ = value;
+}
+inline void LoadDBRequest::set_persistent(bool value) {
+  _internal_set_persistent(value);
+  // @@protoc_insertion_point(field_set:statedb.v1.LoadDBRequest.persistent)
+}
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// LoadProgramDBRequest
+
+// map<string, bytes> input_program_db = 1;
+inline int LoadProgramDBRequest::_internal_input_program_db_size() const {
+  return input_program_db_.size();
+}
+inline int LoadProgramDBRequest::input_program_db_size() const {
+  return _internal_input_program_db_size();
+}
+inline void LoadProgramDBRequest::clear_input_program_db() {
+  input_program_db_.Clear();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+LoadProgramDBRequest::_internal_input_program_db() const {
+  return input_program_db_.GetMap();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >&
+LoadProgramDBRequest::input_program_db() const {
+  // @@protoc_insertion_point(field_map:statedb.v1.LoadProgramDBRequest.input_program_db)
+  return _internal_input_program_db();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+LoadProgramDBRequest::_internal_mutable_input_program_db() {
+  return input_program_db_.MutableMap();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
+LoadProgramDBRequest::mutable_input_program_db() {
+  // @@protoc_insertion_point(field_mutable_map:statedb.v1.LoadProgramDBRequest.input_program_db)
+  return _internal_mutable_input_program_db();
+}
+
+// bool persistent = 2;
+inline void LoadProgramDBRequest::clear_persistent() {
+  persistent_ = false;
+}
+inline bool LoadProgramDBRequest::_internal_persistent() const {
+  return persistent_;
+}
+inline bool LoadProgramDBRequest::persistent() const {
+  // @@protoc_insertion_point(field_get:statedb.v1.LoadProgramDBRequest.persistent)
+  return _internal_persistent();
+}
+inline void LoadProgramDBRequest::_internal_set_persistent(bool value) {
+  
+  persistent_ = value;
+}
+inline void LoadProgramDBRequest::set_persistent(bool value) {
+  _internal_set_persistent(value);
+  // @@protoc_insertion_point(field_set:statedb.v1.LoadProgramDBRequest.persistent)
+}
+
+// -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
 
@@ -4150,7 +5003,36 @@ inline void SetResponse::set_proof_hash_counter(::PROTOBUF_NAMESPACE_ID::uint64 
   // @@protoc_insertion_point(field_set:statedb.v1.SetResponse.proof_hash_counter)
 }
 
-// .statedb.v1.ResultCode result = 12;
+// map<string, .statedb.v1.FeList> db_read_log = 12;
+inline int SetResponse::_internal_db_read_log_size() const {
+  return db_read_log_.size();
+}
+inline int SetResponse::db_read_log_size() const {
+  return _internal_db_read_log_size();
+}
+inline void SetResponse::clear_db_read_log() {
+  db_read_log_.Clear();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+SetResponse::_internal_db_read_log() const {
+  return db_read_log_.GetMap();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+SetResponse::db_read_log() const {
+  // @@protoc_insertion_point(field_map:statedb.v1.SetResponse.db_read_log)
+  return _internal_db_read_log();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+SetResponse::_internal_mutable_db_read_log() {
+  return db_read_log_.MutableMap();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+SetResponse::mutable_db_read_log() {
+  // @@protoc_insertion_point(field_mutable_map:statedb.v1.SetResponse.db_read_log)
+  return _internal_mutable_db_read_log();
+}
+
+// .statedb.v1.ResultCode result = 13;
 inline bool SetResponse::_internal_has_result() const {
   return this != internal_default_instance() && result_ != nullptr;
 }
@@ -4230,6 +5112,8 @@ inline void SetResponse::set_allocated_result(::statedb::v1::ResultCode* result)
   result_ = result;
   // @@protoc_insertion_point(field_set_allocated:statedb.v1.SetResponse.result)
 }
+
+// -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
 
@@ -4711,7 +5595,36 @@ inline void GetResponse::set_proof_hash_counter(::PROTOBUF_NAMESPACE_ID::uint64 
   // @@protoc_insertion_point(field_set:statedb.v1.GetResponse.proof_hash_counter)
 }
 
-// .statedb.v1.ResultCode result = 9;
+// map<string, .statedb.v1.FeList> db_read_log = 9;
+inline int GetResponse::_internal_db_read_log_size() const {
+  return db_read_log_.size();
+}
+inline int GetResponse::db_read_log_size() const {
+  return _internal_db_read_log_size();
+}
+inline void GetResponse::clear_db_read_log() {
+  db_read_log_.Clear();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+GetResponse::_internal_db_read_log() const {
+  return db_read_log_.GetMap();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >&
+GetResponse::db_read_log() const {
+  // @@protoc_insertion_point(field_map:statedb.v1.GetResponse.db_read_log)
+  return _internal_db_read_log();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+GetResponse::_internal_mutable_db_read_log() {
+  return db_read_log_.MutableMap();
+}
+inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, ::statedb::v1::FeList >*
+GetResponse::mutable_db_read_log() {
+  // @@protoc_insertion_point(field_mutable_map:statedb.v1.GetResponse.db_read_log)
+  return _internal_mutable_db_read_log();
+}
+
+// .statedb.v1.ResultCode result = 10;
 inline bool GetResponse::_internal_has_result() const {
   return this != internal_default_instance() && result_ != nullptr;
 }
@@ -5129,6 +6042,57 @@ inline void Fea::set_fe3(::PROTOBUF_NAMESPACE_ID::uint64 value) {
 
 // -------------------------------------------------------------------
 
+// FeList
+
+// repeated uint64 fe = 1;
+inline int FeList::_internal_fe_size() const {
+  return fe_.size();
+}
+inline int FeList::fe_size() const {
+  return _internal_fe_size();
+}
+inline void FeList::clear_fe() {
+  fe_.Clear();
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 FeList::_internal_fe(int index) const {
+  return fe_.Get(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 FeList::fe(int index) const {
+  // @@protoc_insertion_point(field_get:statedb.v1.FeList.fe)
+  return _internal_fe(index);
+}
+inline void FeList::set_fe(int index, ::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  fe_.Set(index, value);
+  // @@protoc_insertion_point(field_set:statedb.v1.FeList.fe)
+}
+inline void FeList::_internal_add_fe(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  fe_.Add(value);
+}
+inline void FeList::add_fe(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_add_fe(value);
+  // @@protoc_insertion_point(field_add:statedb.v1.FeList.fe)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >&
+FeList::_internal_fe() const {
+  return fe_;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >&
+FeList::fe() const {
+  // @@protoc_insertion_point(field_list:statedb.v1.FeList.fe)
+  return _internal_fe();
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >*
+FeList::_internal_mutable_fe() {
+  return &fe_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedField< ::PROTOBUF_NAMESPACE_ID::uint64 >*
+FeList::mutable_fe() {
+  // @@protoc_insertion_point(field_mutable_list:statedb.v1.FeList.fe)
+  return _internal_mutable_fe();
+}
+
+// -------------------------------------------------------------------
+
 // SiblingList
 
 // repeated uint64 sibling = 1;
@@ -5205,6 +6169,20 @@ inline void ResultCode::set_code(::statedb::v1::ResultCode_Code value) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/grpc/proto/statedb.proto
+++ b/src/grpc/proto/statedb.proto
@@ -25,6 +25,8 @@ service StateDBService {
     rpc Get(GetRequest) returns (GetResponse) {}
     rpc SetProgram(SetProgramRequest) returns (SetProgramResponse) {}
     rpc GetProgram(GetProgramRequest) returns (GetProgramResponse) {}
+    rpc LoadDB(LoadDBRequest) returns (google.protobuf.Empty) {}
+    rpc LoadProgramDB(LoadProgramDBRequest) returns (google.protobuf.Empty) {}
     rpc Flush (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
 
@@ -37,8 +39,9 @@ service StateDBService {
  * @param {old_root} - merkle-tree root
  * @param {key} - key to set
  * @param {value} - scalar value to set (HEX string format)
- * @param {persistent} - indicates if it should be stored in the database (true) or only in the memory cache (false)
+ * @param {persistent} - indicates if it should be stored in the SQL database (true) or only in the memory cache (false)
  * @param {details} - indicates if it should return all response parameters (true) or just the new root (false)
+ * @param {get_db_read_log} - indicates if it should return the DB reads generated during the execution of the request
  */
 message SetRequest {
     Fea old_root = 1;
@@ -46,6 +49,7 @@ message SetRequest {
     string value = 3;
     bool persistent = 4;
     bool details = 5;
+    bool get_db_read_log = 6;
 }
 
 /**
@@ -53,18 +57,20 @@ message SetRequest {
  * @param {root} - merkle-tree root
  * @param {key} - key to look for
  * @param {details} - indicates if it should return all response parameters (true) or just the new root (false)
+ * @param {get_db_read_log} - indicates if it should return the DB reads generated during the execution of the request
  */
 message GetRequest {
     Fea root = 1;
     Fea key = 2;
     bool details = 3;
+    bool get_db_read_log = 4;
 }
 
 /**
  * @dev SetProgramRequest
  * @param {key} - key to set
  * @param {data} - Program data to store
- * @param {persistent} - indicates if it should be stored in the database (true) or only in the memory cache (false)
+ * @param {persistent} - indicates if it should be stored in the SQL database (true) or only in the memory cache (false)
  */
 message SetProgramRequest {
     Fea key = 1;
@@ -78,6 +84,26 @@ message SetProgramRequest {
  */
 message GetProgramRequest {
     Fea key = 1;
+}
+
+/**
+ * @dev LoadDBRequest
+ * @param {input_db} - list of db records (MT) to load in the database
+ * @param {persistent} - indicates if it should be stored in the SQL database (true) or only in the memory cache (false)
+ */
+message LoadDBRequest {
+    map<string, FeList> input_db = 1;
+    bool persistent = 2;
+}
+
+/**
+ * @dev LoadProgramDBRequest
+ * @param {input_program_db} - list of db records (program) to load in the database
+ * @param {persistent} - indicates if it should be stored in the SQL database (true) or only in the memory cache (false)
+ */
+message LoadProgramDBRequest {
+    map<string, bytes> input_program_db = 1;
+    bool persistent = 2;
 }
 
 /////////////////////
@@ -97,6 +123,7 @@ message GetProgramRequest {
  * @param {new_value} - new value (HEX string format)
  * @param {mode}
  * @param {proof_hash_counter}
+ * @param {db_read_log} - list of db records read during the execution of the request
  * @param {result} - result code
  */
 message SetResponse {
@@ -111,7 +138,8 @@ message SetResponse {
     string new_value = 9;
     string mode = 10;
     uint64 proof_hash_counter = 11;
-    ResultCode result = 12;
+    map<string, FeList> db_read_log = 12;
+    ResultCode result = 13;
 }
 
 /**
@@ -124,6 +152,7 @@ message SetResponse {
  * @param {is_old0} - is new insert or delete
  * @param {value} - value retrieved (HEX string format)
  * @param {proof_hash_counter}
+ * @param {db_read_log} - list of db records read during the execution of the request
  * @param {result} - result code
  */
 message GetResponse {
@@ -135,7 +164,8 @@ message GetResponse {
     bool is_old0 = 6;
     string value = 7;
     uint64 proof_hash_counter = 8;
-    ResultCode result = 9;
+    map<string, FeList> db_read_log = 9;
+    ResultCode result = 10;
 }
 
 /**
@@ -171,8 +201,16 @@ message Fea {
 }
 
 /**
+ * @dev FE (Field Element) List
+ * @param {fe} - list of Fe
+*/
+message FeList {
+    repeated uint64 fe = 1;
+}
+
+/**
  * @dev Siblings List
- * @param {sibling} - sibling
+ * @param {sibling} - list of siblings
 */
 message SiblingList {
     repeated uint64 sibling = 1;

--- a/src/prover/input.hpp
+++ b/src/prover/input.hpp
@@ -41,7 +41,7 @@ public:
 
     // Saves the input object data into a JSON object
     void save (json &input) const;
-    void save (json &input, Database &database) const;
+    void save (json &input, DatabaseMap &dbReadLog) const;
 
 private:
     void loadGlobals      (json &input);
@@ -53,7 +53,7 @@ public:
     map< string, vector<uint8_t> > contractsBytecode;
     void loadDatabase     (json &input);
     void saveDatabase     (json &input) const;
-    void saveDatabase     (json &input, Database &database) const;
+    void saveDatabase     (json &input, DatabaseMap &dbReadLog) const;
     zkresult preprocessTxs(void);
 };
 

--- a/src/prover/prover.cpp
+++ b/src/prover/prover.cpp
@@ -266,13 +266,9 @@ void Prover::processBatch(ProverRequest *pProverRequest)
     // Save input to <timestamp>.input.json after execution including dbReadLog
     if (config.saveDbReadsToFile)
     {
-        Database *pDatabase = executor.mainExecutor.pStateDB->getDatabase();
-        if (pDatabase != NULL)
-        {
-            json inputJsonEx;
-            pProverRequest->input.save(inputJsonEx, *pDatabase);
-            json2file(inputJsonEx, pProverRequest->inputFileEx);
-        }
+        json inputJsonEx;
+        pProverRequest->input.save(inputJsonEx, *pProverRequest->dbReadLog);
+        json2file(inputJsonEx, pProverRequest->inputFileEx);
     }
 
     TimerStopAndLog(PROVER_PROCESS_BATCH);
@@ -339,13 +335,9 @@ void Prover::prove(ProverRequest *pProverRequest)
     // Save input to <timestamp>.input.json after execution including dbReadLog
     if (config.saveDbReadsToFile)
     {
-        Database *pDatabase = executor.mainExecutor.pStateDB->getDatabase();
-        if (pDatabase != NULL)
-        {
-            json inputJsonEx;
-            pProverRequest->input.save(inputJsonEx, *pDatabase);
-            json2file(inputJsonEx, pProverRequest->inputFileEx);
-        }
+        json inputJsonEx;
+        pProverRequest->input.save(inputJsonEx, *pProverRequest->dbReadLog);
+        json2file(inputJsonEx, pProverRequest->inputFileEx);
     }
 
     if (pProverRequest->result == ZKR_SUCCESS)

--- a/src/prover/prover_request.cpp
+++ b/src/prover/prover_request.cpp
@@ -15,11 +15,30 @@ void ProverRequest::init (const Config &config, bool bExecutor)
     else
     {
         sfile = "input_prover.json";
-    } 
-   
+    }
+
     filePrefix = config.outputPath + "/" + timestamp + "_" + uuid + ".";
     inputFile = filePrefix + sfile;
     inputFileEx = filePrefix + "db." + sfile;
     publicFile = filePrefix + config.publicFile;
     proofFile = filePrefix + config.proofFile;
+
+    if (config.saveDbReadsToFile) {
+        dbReadLog = new DatabaseMap();
+        if (config.saveDbReadsToFileOnChange)
+            dbReadLog->setOnChangeCallback(this, ProverRequest::onDBReadLogChangeCallback);
+    }
+}
+
+void ProverRequest::onDBReadLogChange(DatabaseMap *dbMap)
+{
+    json inputJsonEx;
+    input.save(inputJsonEx, *dbMap);
+    json2file(inputJsonEx, inputFileEx);
+}
+
+ProverRequest::~ProverRequest()
+{
+    if (dbReadLog != NULL)
+        delete dbReadLog;
 }

--- a/src/service/statedb/statedb.cpp
+++ b/src/service/statedb/statedb.cpp
@@ -6,85 +6,108 @@
 #include "config.hpp"
 #include "scalar.hpp"
 #include "zkresult.hpp"
+#include "database_map.hpp"
 
-StateDB::StateDB (Goldilocks &fr, const Config &config) : fr(fr), config(config), db(fr), smt(fr)
+StateDB::StateDB(Goldilocks &fr, const Config &config) : fr(fr), config(config), db(fr), smt(fr)
 {
     db.init(config);
 }
 
-zkresult StateDB::set (const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result) 
+zkresult StateDB::set(const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result, DatabaseMap *dbReadLog)
 {
-    unique_lock<mutex> guard(mlock);
-    
-    SmtSetResult* r;
-    if (result==NULL) r = new SmtSetResult;
+    lock_guard<recursive_mutex> guard(mlock);
+
+    SmtSetResult *r;
+    if (result == NULL) r = new SmtSetResult;
     else r = result;
 
-    zkresult zkr = smt.set (db, oldRoot, key, value, persistent, *r);
-    for (int i=0; i<4; i++) newRoot[i] = r->newRoot[i];
+    zkresult zkr = smt.set(db, oldRoot, key, value, persistent, *r, dbReadLog);
+    for (int i = 0; i < 4; i++) newRoot[i] = r->newRoot[i];
 
-    if (result==NULL) delete r;
+    if (result == NULL) delete r;
 
     return zkr;
 }
 
-zkresult StateDB::get (const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result)
+zkresult StateDB::get(const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result, DatabaseMap *dbReadLog)
 {
-    unique_lock<mutex> guard(mlock);
-    
-    SmtGetResult* r;
-    if (result==NULL) r = new SmtGetResult;
+    lock_guard<recursive_mutex> guard(mlock);
+
+    SmtGetResult *r;
+    if (result == NULL) r = new SmtGetResult;
     else r = result;
 
-    zkresult zkr = smt.get (db, root, key, *r);
+    zkresult zkr = smt.get(db, root, key, *r, dbReadLog);
+
     value = r->value;
 
-    if (result==NULL) delete r;
+    if (result == NULL) delete r;
 
     return zkr;
 }
 
-zkresult StateDB::setProgram (const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent)
+zkresult StateDB::setProgram(const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent)
 {
-    unique_lock<mutex> guard(mlock);
+    lock_guard<recursive_mutex> guard(mlock);
 
-    return db.setProgram (fea2string(fr, key), data, persistent);
+    return db.setProgram(fea2string(fr, key), data, persistent);
 }
 
-zkresult StateDB::getProgram (const Goldilocks::Element (&key)[4], vector<uint8_t> &data)
+zkresult StateDB::getProgram(const Goldilocks::Element (&key)[4], vector<uint8_t> &data, DatabaseMap *dbReadLog)
 {
-    unique_lock<mutex> guard(mlock);
-    
-    return db.getProgram (fea2string(fr, key), data);
+    lock_guard<recursive_mutex> guard(mlock);
+
+    zkresult zkr = db.getProgram(fea2string(fr, key), data, dbReadLog);
+
+    return zkr;
+}
+
+void StateDB::loadDB(const DatabaseMap::MTMap &input, const bool persistent)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    DatabaseMap::MTMap::const_iterator it;
+    for (it = input.begin(); it != input.end(); it++)
+    {
+        db.write(it->first, it->second, persistent);
+    }
+}
+
+void StateDB::loadProgramDB(const DatabaseMap::ProgramMap &input, const bool persistent)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    DatabaseMap::ProgramMap::const_iterator it;
+    for (it = input.begin(); it != input.end(); it++)
+    {
+        db.setProgram(it->first, it->second, persistent);
+    }
 }
 
 void StateDB::flush()
 {
-    unique_lock<mutex> guard(mlock);
+    lock_guard<recursive_mutex> guard(mlock);
 
     db.flush();
 }
 
-Database * StateDB::getDatabase (void)
+void StateDB::setAutoCommit(const bool autoCommit)
 {
-    return &db;
-}
+    lock_guard<recursive_mutex> guard(mlock);
 
-void StateDB::setAutoCommit (const bool autoCommit)
-{
-    db.setAutoCommit (autoCommit);
+    db.setAutoCommit(autoCommit);
 }
 
 void StateDB::commit()
 {
-    unique_lock<mutex> guard(mlock);
-    
+    lock_guard<recursive_mutex> guard(mlock);
+
     db.commit();
 }
 
-void StateDB::hashSave (const Goldilocks::Element (&a)[8], const Goldilocks::Element (&c)[4], const bool persistent, Goldilocks::Element (&hash)[4])
+void StateDB::hashSave(const Goldilocks::Element (&a)[8], const Goldilocks::Element (&c)[4], const bool persistent, Goldilocks::Element (&hash)[4])
 {
-    unique_lock<mutex> guard(mlock);
+    lock_guard<recursive_mutex> guard(mlock);
 
     smt.hashSave(db, a, c, persistent, hash);
 }

--- a/src/service/statedb/statedb.hpp
+++ b/src/service/statedb/statedb.hpp
@@ -15,21 +15,22 @@ private:
     const Config &config;
     Database db;
     Smt smt;
-    mutex mlock;
+    recursive_mutex mlock;
 
 public:
-    StateDB (Goldilocks &fr, const Config &config);
-    zkresult set (const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result);
-    zkresult get (const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result);
-    zkresult setProgram (const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent);
-    zkresult getProgram (const Goldilocks::Element (&key)[4], vector<uint8_t> &data);
-    void flush ();
-    Database * getDatabase (void);
+    StateDB(Goldilocks &fr, const Config &config);
+    zkresult set(const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result, DatabaseMap *dbReadLog);
+    zkresult get(const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result, DatabaseMap *dbReadLog);
+    zkresult setProgram(const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent);
+    zkresult getProgram(const Goldilocks::Element (&key)[4], vector<uint8_t> &data, DatabaseMap *dbReadLog);
+    void loadDB(const DatabaseMap::MTMap &inputDB, const bool persistent);
+    void loadProgramDB(const DatabaseMap::ProgramMap &inputProgramDB, const bool persistent);
+    void flush();
 
     // Methods added for testing purposes
-    void setAutoCommit (const bool autoCommit);
-    void commit ();
-    void hashSave (const Goldilocks::Element (&a)[8], const Goldilocks::Element (&c)[4], const bool persistent, Goldilocks::Element (&hash)[4]);
+    void setAutoCommit(const bool autoCommit);
+    void commit();
+    void hashSave(const Goldilocks::Element (&a)[8], const Goldilocks::Element (&c)[4], const bool persistent, Goldilocks::Element (&hash)[4]);
 };
 
 #endif

--- a/src/service/statedb/statedb_factory.cpp
+++ b/src/service/statedb/statedb_factory.cpp
@@ -5,25 +5,20 @@
 #include "statedb_remote.hpp"
 #include "utils.hpp"
 
-StateDBInterface * pLocalClient = NULL;
-
 StateDBInterface* StateDBClientFactory::createStateDBClient (Goldilocks &fr, const Config &config)
 {
     if (config.stateDBURL=="local")
     {
+        StateDBInterface *pLocalClient = new StateDB (fr, config);
         if (pLocalClient == NULL)
         {
-            pLocalClient = new StateDB (fr, config);
-            if (pLocalClient == NULL)
-            {
-                cerr << "Error: StateDBClientFactory::createStateDBClient() failed calling new StateDB()" << endl;
-                exitProcess();
-            }
+            cerr << "Error: StateDBClientFactory::createStateDBClient() failed calling new StateDB()" << endl;
+            exitProcess();
         }
         return pLocalClient;
     }
 
-    StateDBInterface * pRemoteClient = new StateDBRemote (fr, config);
+    StateDBInterface *pRemoteClient = new StateDBRemote (fr, config);
     if (pRemoteClient == NULL)
     {
         cerr << "Error: StateDBClientFactory::createStateDBClient() failed calling new StateDBRemote()" << endl;
@@ -41,9 +36,5 @@ void StateDBClientFactory::freeStateDBClient (StateDBInterface * pStateDB)
         exitProcess();
     }
 
-    // Delete only remote instances
-    if (pStateDB != pLocalClient)
-    {
-        delete pStateDB;
-    }
+    delete pStateDB;
 }

--- a/src/service/statedb/statedb_interface.hpp
+++ b/src/service/statedb/statedb_interface.hpp
@@ -3,21 +3,23 @@
 
 #include "goldilocks_base_field.hpp"
 #include "database.hpp"
+#include "database_map.hpp"
 #include "config.hpp"
 #include "smt.hpp"
 #include <mutex>
 #include "zkresult.hpp"
 
-class StateDBInterface 
+class StateDBInterface
 {
 public:
-    virtual ~StateDBInterface() {};
-    virtual zkresult set (const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result) = 0;
-    virtual zkresult get (const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result) = 0;
-    virtual zkresult setProgram (const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent) = 0;
-    virtual zkresult getProgram (const Goldilocks::Element (&key)[4], vector<uint8_t> &data) = 0;
+    virtual ~StateDBInterface(){};
+    virtual zkresult set(const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result, DatabaseMap *dbReadLog) = 0;
+    virtual zkresult get(const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result, DatabaseMap *dbReadLog) = 0;
+    virtual zkresult setProgram(const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent) = 0;
+    virtual zkresult getProgram(const Goldilocks::Element (&key)[4], vector<uint8_t> &data, DatabaseMap *dbReadLog) = 0;
+    virtual void loadDB(const DatabaseMap::MTMap &input, const bool persistent) = 0;
+    virtual void loadProgramDB(const DatabaseMap::ProgramMap &input, const bool persistent) = 0;
     virtual void flush() = 0;
-    virtual Database * getDatabase (void) = 0; // Returns NULL if remote, &db if local; for testing purposes only
 };
 
 #endif

--- a/src/service/statedb/statedb_remote.hpp
+++ b/src/service/statedb/statedb_remote.hpp
@@ -20,14 +20,15 @@ private:
     ::statedb::v1::StateDBService::Stub *stub;
 
 public:
-    StateDBRemote (Goldilocks &fr, const Config &config);
+    StateDBRemote(Goldilocks &fr, const Config &config);
 
-    zkresult set (const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result);
-    zkresult get (const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result);
-    zkresult setProgram (const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent);
-    zkresult getProgram (const Goldilocks::Element (&key)[4], vector<uint8_t> &data);
+    zkresult set(const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, Goldilocks::Element (&newRoot)[4], SmtSetResult *result, DatabaseMap *dbReadLog);
+    zkresult get(const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], mpz_class &value, SmtGetResult *result, DatabaseMap *dbReadLog);
+    zkresult setProgram(const Goldilocks::Element (&key)[4], const vector<uint8_t> &data, const bool persistent);
+    zkresult getProgram(const Goldilocks::Element (&key)[4], vector<uint8_t> &data, DatabaseMap *dbReadLog);
+    void loadDB(const DatabaseMap::MTMap &input, const bool persistent);
+    void loadProgramDB(const DatabaseMap::ProgramMap &input, const bool persistent);
     void flush();
-    Database * getDatabase (void);
 };
 
 #endif

--- a/src/service/statedb/statedb_server.cpp
+++ b/src/service/statedb/statedb_server.cpp
@@ -13,13 +13,18 @@ using grpc::Status;
 void StateDBServer::run (void)
 {
     ServerBuilder builder;
+
+    grpc::ResourceQuota rq;
+    rq.SetMaxThreads(4);
+    builder.SetResourceQuota(rq);
+
     StateDBServiceImpl service(fr, config, true, false);
 
     std::string server_address("0.0.0.0:" + to_string(config.stateDBServerPort));
 
     grpc::EnableDefaultHealthCheckService(true);
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
-    
+
     // Listen on the given address without any authentication mechanism.
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
 
@@ -29,7 +34,7 @@ void StateDBServer::run (void)
 
     // Finally assemble the server.
     std::unique_ptr<Server> server(builder.BuildAndStart());
-    
+
     std::cout << "StateDB server listening on " << server_address << std::endl;
 
     // Wait for the server to shutdown. Note that some other thread must be

--- a/src/service/statedb/statedb_service.hpp
+++ b/src/service/statedb/statedb_service.hpp
@@ -18,6 +18,8 @@ public:
     ::grpc::Status Get (::grpc::ServerContext* context, const ::statedb::v1::GetRequest* request, ::statedb::v1::GetResponse* response) override;
     ::grpc::Status SetProgram (::grpc::ServerContext* context, const ::statedb::v1::SetProgramRequest* request, ::statedb::v1::SetProgramResponse* response) override;
     ::grpc::Status GetProgram (::grpc::ServerContext* context, const ::statedb::v1::GetProgramRequest* request, ::statedb::v1::GetProgramResponse* response) override;
+    ::grpc::Status LoadDB(::grpc::ServerContext* context, const ::statedb::v1::LoadDBRequest* request, ::google::protobuf::Empty* response);
+    ::grpc::Status LoadProgramDB(::grpc::ServerContext* context, const ::statedb::v1::LoadProgramDBRequest* request, ::google::protobuf::Empty* response);
     ::grpc::Status Flush (::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::google::protobuf::Empty* response) override;
 };
 

--- a/src/service/statedb/statedb_utils.cpp
+++ b/src/service/statedb/statedb_utils.cpp
@@ -1,16 +1,77 @@
+#include "statedb_utils.hpp"
 #include "statedb.grpc.pb.h"
 #include "goldilocks_base_field.hpp"
+#include "database.hpp"
 
-void fea2grpc (Goldilocks &fr, const Goldilocks::Element (&fea)[4], ::statedb::v1::Fea* grpcFea) {
+void fea2grpc (Goldilocks &fr, const Goldilocks::Element (&fea)[4], ::statedb::v1::Fea *grpcFea)
+{
     grpcFea->set_fe0(fr.toU64(fea[0]));
     grpcFea->set_fe1(fr.toU64(fea[1]));
     grpcFea->set_fe2(fr.toU64(fea[2]));
     grpcFea->set_fe3(fr.toU64(fea[3]));
 }
 
-void grpc2fea (Goldilocks &fr, const ::statedb::v1::Fea& grpcFea, Goldilocks::Element (&fea)[4]) {
+void grpc2fea (Goldilocks &fr, const ::statedb::v1::Fea& grpcFea, Goldilocks::Element (&fea)[4])
+{
     fea[0] = fr.fromU64(grpcFea.fe0());
     fea[1] = fr.fromU64(grpcFea.fe1());
     fea[2] = fr.fromU64(grpcFea.fe2());
     fea[3] = fr.fromU64(grpcFea.fe3());
 }
+
+void mtMap2grpc(Goldilocks &fr, const DatabaseMap::MTMap &map, ::PROTOBUF_NAMESPACE_ID::Map<string, ::statedb::v1::FeList> *grpcMap)
+{
+    DatabaseMap::MTMap::const_iterator it;
+    for (it = map.begin(); it != map.end(); it++)
+    {
+        ::statedb::v1::FeList list;
+        for (uint64_t i=0; i<it->second.size(); i++)
+        {
+            list.add_fe(fr.toU64(it->second[i]));
+        }
+        (*grpcMap)[it->first] = list;
+    }
+}
+
+void programMap2grpc(Goldilocks &fr, const DatabaseMap::ProgramMap &map, ::PROTOBUF_NAMESPACE_ID::Map<string, string> *grpcMap)
+{
+    DatabaseMap::ProgramMap::const_iterator it;
+    for (it = map.begin(); it != map.end(); it++)
+    {
+        string sData;
+        for (uint64_t i = 0; i < it->second.size(); i++) {
+            sData.push_back((char)it->second.at(i));
+        }
+        (*grpcMap)[it->first] = sData;
+    }
+}
+
+void grpc2mtMap(Goldilocks &fr, const ::PROTOBUF_NAMESPACE_ID::Map<string, ::statedb::v1::FeList> &grpcMap, DatabaseMap::MTMap &map)
+{
+    ::PROTOBUF_NAMESPACE_ID::Map<string, ::statedb::v1::FeList>::const_iterator it;
+    for (it = grpcMap.begin(); it != grpcMap.end(); it++)
+    {
+        vector<Goldilocks::Element> list;
+        for (int i = 0; i < it->second.fe_size(); i++)
+        {
+            list.push_back(fr.fromU64(it->second.fe(i)));
+        }
+        map[it->first] = list;
+    }
+}
+
+void grpc2programMap(Goldilocks &fr, const ::PROTOBUF_NAMESPACE_ID::Map<string, string> &grpcMap, DatabaseMap::ProgramMap &map)
+{
+    ::PROTOBUF_NAMESPACE_ID::Map<string, string>::const_iterator it;
+    for (it = grpcMap.begin(); it != grpcMap.end(); it++)
+    {
+        vector<uint8_t> list;
+        for (size_t i=0; i < it->second.size(); i++)
+        {
+            list.push_back(it->second.at(i));
+        }
+        map[it->first] = list;
+    }
+}
+
+

--- a/src/service/statedb/statedb_utils.hpp
+++ b/src/service/statedb/statedb_utils.hpp
@@ -3,8 +3,16 @@
 
 #include "statedb.grpc.pb.h"
 #include "goldilocks_base_field.hpp"
+#include <google/protobuf/port_def.inc>
+#include "database.hpp"
 
-void fea2grpc (Goldilocks &fr, const Goldilocks::Element (&fea)[4], ::statedb::v1::Fea* grpcFea);
-void grpc2fea (Goldilocks &fr, const ::statedb::v1::Fea& grpcFea, Goldilocks::Element (&fea)[4]);
+using namespace std;
+
+void fea2grpc(Goldilocks &fr, const Goldilocks::Element (&fea)[4], ::statedb::v1::Fea *grpcFea);
+void grpc2fea(Goldilocks &fr, const ::statedb::v1::Fea& grpcFea, Goldilocks::Element (&fea)[4]);
+void mtMap2grpc(Goldilocks &fr, const DatabaseMap::MTMap &map, ::PROTOBUF_NAMESPACE_ID::Map<string, ::statedb::v1::FeList> *grpcMap);
+void programMap2grpc(Goldilocks &fr, const DatabaseMap::ProgramMap &map, ::PROTOBUF_NAMESPACE_ID::Map<string, string> *grpcMap);
+void grpc2mtMap(Goldilocks &fr, const ::PROTOBUF_NAMESPACE_ID::Map<string, ::statedb::v1::FeList> &grpcMap, DatabaseMap::MTMap &map);
+void grpc2programMap(Goldilocks &fr, const ::PROTOBUF_NAMESPACE_ID::Map<string, string> &grpcMap, DatabaseMap::ProgramMap &map);
 
 #endif

--- a/src/sm/main/eval_command.cpp
+++ b/src/sm/main/eval_command.cpp
@@ -78,7 +78,7 @@ void eval_declareVar (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     // Check the variable name
     if (cmd.varName == "") {
         cerr << "Error: eval_declareVar() Variable name not found" << " zkPC=" << *ctx.pZKPC << endl;
-        exitProcess();  
+        exitProcess();
     }
 
     // Check that this variable does not exists
@@ -105,7 +105,7 @@ void eval_getVar (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     // Check the variable name
     if (cmd.varName == "") {
         cerr << "Error: eval_getVar() Variable name not found" << " zkPC=" << *ctx.pZKPC << endl;
-        exitProcess();  
+        exitProcess();
     }
 
     // Check that this variable exists
@@ -403,7 +403,7 @@ void eval_logical_operation (Context &ctx, const RomCommand &cmd, CommandResult 
     cr2scalar(ctx.fr, cr, b);
 
     cr.type = crt_scalar;
-    
+
          if (cmd.op == op_or ) cr.scalar = (a || b) ? 1 : 0;
     else if (cmd.op == op_and) cr.scalar = (a && b) ? 1 : 0;
     else if (cmd.op == op_eq ) cr.scalar = (a == b) ? 1 : 0;
@@ -437,7 +437,7 @@ void eval_bit_operation (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     cr2scalar(ctx.fr, cr, b);
 
     cr.type = crt_scalar;
-    
+
          if (cmd.op == op_bitor ) cr.scalar = a | b;
     else if (cmd.op == op_bitand) cr.scalar = a & b;
     else if (cmd.op == op_bitxor) cr.scalar = a ^ b;
@@ -537,45 +537,45 @@ void eval_functionCall (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     switch (cmd.function)
     {
         case f_getGlobalHash:                   return eval_getGlobalHash(ctx, cmd, cr);
-        case f_getGlobalExitRoot:               return eval_getGlobalExitRoot(ctx, cmd, cr);      
-        case f_getOldStateRoot:                 return eval_getOldStateRoot(ctx, cmd, cr);        
-        case f_getNewStateRoot:                 return eval_getNewStateRoot(ctx, cmd, cr);          
-        case f_getSequencerAddr:                return eval_getSequencerAddr(ctx, cmd, cr);         
-        case f_getOldLocalExitRoot:             return eval_getOldLocalExitRoot(ctx, cmd, cr);           
-        case f_getNewLocalExitRoot:             return eval_getNewLocalExitRoot(ctx, cmd, cr);           
+        case f_getGlobalExitRoot:               return eval_getGlobalExitRoot(ctx, cmd, cr);
+        case f_getOldStateRoot:                 return eval_getOldStateRoot(ctx, cmd, cr);
+        case f_getNewStateRoot:                 return eval_getNewStateRoot(ctx, cmd, cr);
+        case f_getSequencerAddr:                return eval_getSequencerAddr(ctx, cmd, cr);
+        case f_getOldLocalExitRoot:             return eval_getOldLocalExitRoot(ctx, cmd, cr);
+        case f_getNewLocalExitRoot:             return eval_getNewLocalExitRoot(ctx, cmd, cr);
         case f_getNumBatch:                     return eval_getBatchNum(ctx, cmd, cr);
         case f_getTimestamp:                    return eval_getTimestamp(ctx, cmd, cr);
         case f_getChainId:                      return eval_getChainId(ctx, cmd, cr);
-        case f_getBatchHashData:                return eval_getBatchHashData(ctx, cmd, cr);             
-        case f_getTxs:                          return eval_getTxs(ctx, cmd, cr);              
-        case f_getTxsLen:                       return eval_getTxsLen(ctx, cmd, cr);             
-        case f_addrOp:                          return eval_addrOp(ctx, cmd, cr);           
-        case f_eventLog:                        return eval_eventLog(ctx, cmd, cr);           
-        case f_cond:                            return eval_cond(ctx, cmd, cr);             
-        case f_inverseFpEc:                     return eval_inverseFpEc(ctx, cmd, cr);               
-        case f_inverseFnEc:                     return eval_inverseFnEc(ctx, cmd, cr);                
-        case f_sqrtFpEc:                        return eval_sqrtFpEc(ctx, cmd, cr);               
-        case f_xAddPointEc:                     return eval_xAddPointEc(ctx, cmd, cr);                
-        case f_yAddPointEc:                     return eval_yAddPointEc(ctx, cmd, cr);                
-        case f_xDblPointEc:                     return eval_xDblPointEc(ctx, cmd, cr);               
-        case f_yDblPointEc:                     return eval_yDblPointEc(ctx, cmd, cr);               
-        case f_getBytecode:                     return eval_getBytecode(ctx, cmd, cr);  
+        case f_getBatchHashData:                return eval_getBatchHashData(ctx, cmd, cr);
+        case f_getTxs:                          return eval_getTxs(ctx, cmd, cr);
+        case f_getTxsLen:                       return eval_getTxsLen(ctx, cmd, cr);
+        case f_addrOp:                          return eval_addrOp(ctx, cmd, cr);
+        case f_eventLog:                        return eval_eventLog(ctx, cmd, cr);
+        case f_cond:                            return eval_cond(ctx, cmd, cr);
+        case f_inverseFpEc:                     return eval_inverseFpEc(ctx, cmd, cr);
+        case f_inverseFnEc:                     return eval_inverseFnEc(ctx, cmd, cr);
+        case f_sqrtFpEc:                        return eval_sqrtFpEc(ctx, cmd, cr);
+        case f_xAddPointEc:                     return eval_xAddPointEc(ctx, cmd, cr);
+        case f_yAddPointEc:                     return eval_yAddPointEc(ctx, cmd, cr);
+        case f_xDblPointEc:                     return eval_xDblPointEc(ctx, cmd, cr);
+        case f_yDblPointEc:                     return eval_yDblPointEc(ctx, cmd, cr);
+        case f_getBytecode:                     return eval_getBytecode(ctx, cmd, cr);
         case f_bitwise_and:
         case f_bitwise_or:
         case f_bitwise_xor:
-        case f_bitwise_not:                     return eval_bitwise(ctx, cmd, cr);           
+        case f_bitwise_not:                     return eval_bitwise(ctx, cmd, cr);
         case f_comp_lt:
         case f_comp_gt:
-        case f_comp_eq:                         return eval_comp(ctx, cmd, cr);            
-        case f_loadScalar:                      return eval_loadScalar(ctx, cmd, cr);            
-        case f_getGlobalExitRootManagerAddr:    return eval_getGlobalExitRootManagerAddr(ctx, cmd, cr);           
-        case f_log:                             return eval_log(ctx, cmd, cr);         
-        case f_exp:                             return eval_exp(ctx, cmd, cr);           
-        case f_storeLog:                        return eval_storeLog(ctx, cmd, cr);             
-        case f_memAlignWR_W0:                   return eval_memAlignWR_W0(ctx, cmd, cr);            
-        case f_memAlignWR_W1:                   return eval_memAlignWR_W1(ctx, cmd, cr);           
-        case f_memAlignWR8_W0:                  return eval_memAlignWR8_W0(ctx, cmd, cr);           
-        case f_saveContractBytecode:            return eval_saveContractBytecode(ctx, cmd, cr); 
+        case f_comp_eq:                         return eval_comp(ctx, cmd, cr);
+        case f_loadScalar:                      return eval_loadScalar(ctx, cmd, cr);
+        case f_getGlobalExitRootManagerAddr:    return eval_getGlobalExitRootManagerAddr(ctx, cmd, cr);
+        case f_log:                             return eval_log(ctx, cmd, cr);
+        case f_exp:                             return eval_exp(ctx, cmd, cr);
+        case f_storeLog:                        return eval_storeLog(ctx, cmd, cr);
+        case f_memAlignWR_W0:                   return eval_memAlignWR_W0(ctx, cmd, cr);
+        case f_memAlignWR_W1:                   return eval_memAlignWR_W1(ctx, cmd, cr);
+        case f_memAlignWR8_W0:                  return eval_memAlignWR8_W0(ctx, cmd, cr);
+        case f_saveContractBytecode:            return eval_saveContractBytecode(ctx, cmd, cr);
         case f_beforeLast:                      return eval_beforeLast(ctx, cmd, cr);
         case f_isWarmedAddress:                 return eval_isWarmedAddress(ctx, cmd, cr);
         case f_checkpoint:                      return eval_checkpoint(ctx, cmd, cr);
@@ -875,7 +875,7 @@ void eval_cond (Context &ctx, const RomCommand &cmd, CommandResult &cr)
         cerr << "Error: eval_cond() unexpected command result type: " << cr.type << " zkPC=" << *ctx.pZKPC << endl;
         exitProcess();
     }
-    
+
     cr.type = crt_fea;
     if (cr.scalar != 0)
     {
@@ -941,7 +941,7 @@ void eval_getBytecode (Context &ctx, const RomCommand &cmd, CommandResult &cr)
 
         // Get the contract from the database
         vector<uint8_t> bytecode;
-        zkresult zkResult = ctx.pStateDB->getProgram(key, bytecode);
+        zkresult zkResult = ctx.pStateDB->getProgram(key, bytecode, ctx.proverRequest.dbReadLog);
         if (zkResult != ZKR_SUCCESS)
         {
             cerr << "Error: eval_getBytecode() failed calling ctx.pStateDB->getProgram() with key=" << hashcontract << " zkResult=" << zkResult << "=" << zkresult2string(zkResult) << endl;
@@ -1004,7 +1004,7 @@ void eval_commit (Context &ctx, const RomCommand &cmd, CommandResult &cr)
         map< mpz_class, set<mpz_class> > storageMap;
         storageMap = ctx.accessedStorage[ctx.accessedStorage.size() - 1];
         ctx.accessedStorage.pop_back();
-        
+
         if (ctx.accessedStorage.size() > 1)
         {
             // Iterate all storageMap addresses
@@ -1098,7 +1098,7 @@ void eval_isWarmedAddress (Context &ctx, const RomCommand &cmd, CommandResult &c
         cr.fea7 = ctx.fr.zero();
         return;
     }
-    
+
     // If address is warm return 0
     for (int64_t i = ctx.accessedStorage.size() - 1; i >= 0; i--)
     {
@@ -1580,7 +1580,7 @@ void eval_memAlignWR_W0 (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     int64_t shiftLeft = (32 - offset) * 8;
     int64_t shiftRight = offset * 8;
     mpz_class result = (m0 & (Mask256 << shiftLeft)) | (Mask256 & (value >> shiftRight));
-    
+
     cr.type = crt_fea;
     scalar2fea(ctx.fr, result, cr.fea0, cr.fea1, cr.fea2, cr.fea3, cr.fea4, cr.fea5, cr.fea6, cr.fea7);
 }
@@ -1620,7 +1620,7 @@ void eval_memAlignWR_W1 (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     int64_t shiftRight = offset * 8;
     int64_t shiftLeft = (32 - offset) * 8;
     mpz_class result = (m1 & (Mask256 >> shiftRight)) | (Mask256 & (value << shiftLeft));
-    
+
     cr.type = crt_fea;
     scalar2fea(ctx.fr, result, cr.fea0, cr.fea1, cr.fea2, cr.fea3, cr.fea4, cr.fea5, cr.fea6, cr.fea7);
 }
@@ -1658,9 +1658,9 @@ void eval_memAlignWR8_W0 (Context &ctx, const RomCommand &cmd, CommandResult &cr
     int64_t offset = cr.scalar.get_si();
 
     int64_t bits = (31 - offset) * 8;
-    
+
     mpz_class result = (m0 & (Mask256 - (Mask8 << bits))) | ((Mask8 & value ) << bits);
-    
+
     cr.type = crt_fea;
     scalar2fea(ctx.fr, result, cr.fea0, cr.fea1, cr.fea2, cr.fea3, cr.fea4, cr.fea5, cr.fea6, cr.fea7);
 }
@@ -1754,7 +1754,7 @@ void eval_inverseFnEc (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     cr.scalar.set_str(ctx.fnec.toString(r,16), 16);
 }
 
-mpz_class pow ( const mpz_class &x, const mpz_class &n, const mpz_class &p ) 
+mpz_class pow ( const mpz_class &x, const mpz_class &n, const mpz_class &p )
 {
     if (n == 0) return 1;
     if ((n & 1) == 1) {
@@ -1922,7 +1922,7 @@ void eval_AddPointEc (Context &ctx, const RomCommand &cmd, bool dbl, RawFec::Ele
         }
         ctx.fec.fromString(y2, cr.scalar.get_str(16), 16);
     }
-    
+
     RawFec::Element aux1, aux2, s;
 
     if (dbl)

--- a/src/sm/main/main_executor.hpp
+++ b/src/sm/main/main_executor.hpp
@@ -36,12 +36,9 @@ public:
 
     // Poseidon instance
     PoseidonGoldilocks &poseidon;
-    
+
     // ROM JSON file data:
     Rom rom;
-
-    // StateDB interface
-    StateDBInterface *pStateDB;
 
     // Database server configuration, if any
     const Config &config;
@@ -54,7 +51,7 @@ public:
 
     // Constructor
     MainExecutor(Goldilocks &fr, PoseidonGoldilocks &poseidon, const Config &config);
-    
+
     // Destructor
     ~MainExecutor();
 

--- a/src/statedb/database.hpp
+++ b/src/statedb/database.hpp
@@ -9,8 +9,11 @@
 #include "config.hpp"
 #include <semaphore.h>
 #include "zkresult.hpp"
+#include "database_map.hpp"
 
 using namespace std;
+
+class DatabaseMap;
 
 class Database
 {
@@ -31,45 +34,32 @@ private:
     pqxx::connection * pAsyncWriteConnection = NULL;
     pqxx::work* transaction = NULL;
 
-    // Local database based on a map attribute
-    map<string, vector<Goldilocks::Element>> db; // This is in fact a map<fe,fe[16]>
-
-public:
-    map<string, vector<Goldilocks::Element>> dbReadLog; // Log data read from the database
-private:
-    pthread_mutex_t mutex;    // Mutex to protect the dbReadLog access
-public:
-    void lock(void) { pthread_mutex_lock(&mutex); };
-    void unlock(void) { pthread_mutex_unlock(&mutex); };
-
 private:
     // Remote database based on Postgres (PostgreSQL)
-    void initRemote (void);
-    zkresult readRemote (const string &key, vector<Goldilocks::Element> &value);
-    zkresult writeRemote (const string &key, const vector<Goldilocks::Element> &value);
-    void addWriteQueue (const string sqlWrite);
-    void signalEmptyWriteQueue () {  };
+    void initRemote(void);
+    zkresult readRemote(const string &key, string &value);
+    zkresult writeRemote(const string &key, const string &value);
+    void addWriteQueue(const string sqlWrite);
+    void signalEmptyWriteQueue() {};
 
 public:
-    Database(Goldilocks &fr) : fr(fr)
-    {
-        pthread_mutex_init(&mutex, NULL);
-    };
+    static DatabaseMap dbCache; // Local database based on a map attribute
+
+    Database(Goldilocks &fr) : fr(fr) {};
     ~Database();
-    void init (const Config &config);
-    zkresult read (const string &key, vector<Goldilocks::Element> &value);
-    zkresult write (const string &key, const vector<Goldilocks::Element> &value, const bool persistent);
-    zkresult setProgram (const string &key, const vector<uint8_t> &value, const bool persistent);
-    zkresult getProgram (const string &key, vector<uint8_t> &value);
-    void processWriteQueue ();
-    void setAutoCommit (const bool autoCommit);
-    void commit ();
-    void flush ();    
-    void clearDbReadLog ();
-    void print (void);
-    void printTree (const string &root, string prefix = "");
+    void init(const Config &config);
+    zkresult read(const string &_key, vector<Goldilocks::Element> &value, DatabaseMap *dbReadLog);
+    zkresult write(const string &_key, const vector<Goldilocks::Element> &value, const bool persistent);
+    zkresult getProgram(const string &_key, vector<uint8_t> &value, DatabaseMap *dbReadLog);
+    zkresult setProgram(const string &_key, const vector<uint8_t> &value, const bool persistent);
+    void processWriteQueue();
+    void setAutoCommit(const bool autoCommit);
+    void commit();
+    void flush();
+    void print(void);
+    void printTree(const string &root, string prefix = "");
 };
 
-void* asyncDatabaseWriteThread (void* arg);
+void* asyncDatabaseWriteThread(void* arg);
 
 #endif

--- a/src/statedb/database_map.cpp
+++ b/src/statedb/database_map.cpp
@@ -1,0 +1,92 @@
+#include "database_map.hpp"
+#include "utils.hpp"
+#include "scalar.hpp"
+
+void DatabaseMap::add(const string key, vector<Goldilocks::Element> value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    mtDB[key] = value;
+    if (callbackOnChange) onChangeCallback();
+}
+
+void DatabaseMap::add(const string key, vector<uint8_t> value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    programDB[key] = value;
+    if (callbackOnChange) onChangeCallback();
+}
+
+void DatabaseMap::add(MTMap &db)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    mtDB.insert(db.begin(), db.end());
+    if (callbackOnChange) onChangeCallback();
+}
+
+void DatabaseMap::add(ProgramMap &db)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    programDB.insert(db.begin(), db.end());
+    if (callbackOnChange) onChangeCallback();
+}
+
+bool DatabaseMap::findMT(const string key, vector<Goldilocks::Element> &value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if (mtDB.find(key) != mtDB.end())
+    {
+        value = mtDB[key];
+        return true;
+    }
+
+    return false;
+}
+
+bool DatabaseMap::findProgram(const string key, vector<uint8_t> &value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if (programDB.find(key) != programDB.end())
+    {
+        value = programDB[key];
+        return true;
+    }
+
+    return false;
+}
+
+map<string, vector<Goldilocks::Element>> DatabaseMap::getMTDB()
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    return mtDB;
+}
+
+map<string, vector<uint8_t>> DatabaseMap::getProgramDB()
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    return programDB;
+}
+
+void DatabaseMap::setOnChangeCallback(void *instance, onChangeCallbackFunctionPtr function)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if ((instance != NULL) && (function != NULL))
+    {
+        cbFunction = function;
+        cbInstance = instance;
+        callbackOnChange = true;
+    } else callbackOnChange = false;
+}
+
+void DatabaseMap::onChangeCallback()
+{
+    cbFunction(cbInstance, this);
+}

--- a/src/statedb/database_map.hpp
+++ b/src/statedb/database_map.hpp
@@ -1,0 +1,46 @@
+#ifndef DATABASE_MAP_HPP
+#define DATABASE_MAP_HPP
+
+#include <vector>
+#include "goldilocks_base_field.hpp"
+#include <nlohmann/json.hpp>
+#include <mutex>
+
+using namespace std;
+using json = nlohmann::json;
+
+class DatabaseMap;
+
+
+class DatabaseMap
+{
+public:
+    typedef map<string, vector<Goldilocks::Element>> MTMap;
+    typedef map<string, vector<uint8_t>> ProgramMap;
+
+private:
+    typedef void(*onChangeCallbackFunctionPtr)(void*, DatabaseMap *dbMap);
+
+    recursive_mutex mlock;
+    MTMap mtDB;
+    ProgramMap programDB;
+    bool callbackOnChange = false;
+    onChangeCallbackFunctionPtr cbFunction = NULL;
+    void *cbInstance = NULL;
+
+    void onChangeCallback();
+
+public:
+    DatabaseMap(){};
+    void add(const string key, vector<Goldilocks::Element> value);
+    void add(const string key, vector<uint8_t> value);
+    void add(MTMap &db);
+    void add(ProgramMap &db);
+    bool findMT(const string key, vector<Goldilocks::Element> &value);
+    bool findProgram(const string key, vector<uint8_t> &value);
+    MTMap getMTDB();
+    ProgramMap getProgramDB();
+    void setOnChangeCallback(void *instance, onChangeCallbackFunctionPtr function);
+};
+
+#endif

--- a/src/statedb/smt.hpp
+++ b/src/statedb/smt.hpp
@@ -9,6 +9,7 @@
 #include "goldilocks_base_field.hpp"
 #include "compare_fe.hpp"
 #include "database.hpp"
+#include "database_map.hpp"
 #include "zkresult.hpp"
 
 using namespace std;
@@ -54,12 +55,12 @@ private:
     PoseidonGoldilocks poseidon;
 public:
     Smt(Goldilocks &fr) : fr(fr) {}
-    zkresult set ( Database &db, const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, SmtSetResult &result );
-    zkresult get ( Database &db, const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], SmtGetResult &result );
-    void splitKey ( const Goldilocks::Element (&key)[4], vector<uint64_t> &result);
-    void joinKey ( const vector<uint64_t> &bits, const Goldilocks::Element (&rkey)[4], Goldilocks::Element (&key)[4] );
-    void removeKeyBits ( const Goldilocks::Element (&key)[4], uint64_t nBits, Goldilocks::Element (&rkey)[4]);
-    void hashSave ( Database &db, const Goldilocks::Element (&a)[8], const Goldilocks::Element (&c)[4], const bool persistent, Goldilocks::Element (&hash)[4]);
+    zkresult set(Database &db, const Goldilocks::Element (&oldRoot)[4], const Goldilocks::Element (&key)[4], const mpz_class &value, const bool persistent, SmtSetResult &result, DatabaseMap *dbReadLog);
+    zkresult get(Database &db, const Goldilocks::Element (&root)[4], const Goldilocks::Element (&key)[4], SmtGetResult &result, DatabaseMap *dbReadLog);
+    void splitKey(const Goldilocks::Element (&key)[4], vector<uint64_t> &result);
+    void joinKey(const vector<uint64_t> &bits, const Goldilocks::Element (&rkey)[4], Goldilocks::Element (&key)[4]);
+    void removeKeyBits(const Goldilocks::Element (&key)[4], uint64_t nBits, Goldilocks::Element (&rkey)[4]);
+    void hashSave(Database &db, const Goldilocks::Element (&a)[8], const Goldilocks::Element (&c)[4], const bool persistent, Goldilocks::Element (&hash)[4]);
     int64_t getUniqueSibling(vector<Goldilocks::Element> &a);
 };
 

--- a/src/utils/scalar.cpp
+++ b/src/utils/scalar.cpp
@@ -113,7 +113,7 @@ void fea2scalar (Goldilocks &fr, mpz_class &scalar, const Goldilocks::Element (&
     }
     scalar += aux;
     scalar = scalar<<32;
-    
+
     // Add field element 1
     aux = fr.toU64(fea[1]);
     if (aux >= 0x100000000)
@@ -357,7 +357,7 @@ string PrependZeros (string s, uint64_t n)
 
     // Prepend zeros if needed
     if (stringSize < n) return sZeros[n-stringSize] + s;
-    
+
     return s;
 }
 
@@ -440,7 +440,6 @@ string byte2string(uint8_t b)
     string result;
     result.push_back(byte2char(b >> 4));
     result.push_back(byte2char(b & 0x0F));
-    result.push_back(0);
     return result;
 }
 
@@ -498,6 +497,24 @@ string string2ba (const string &textString)
     string result;
     string2ba(textString, result);
     return result;
+}
+
+uint64_t string2bv (const string &os, vector<uint8_t> &vData)
+{
+    string s = Remove0xIfPresent(os);
+
+    if (s.size()%2 != 0)
+    {
+        s = "0" + s;
+    }
+
+    uint64_t dsize = s.size()/2;
+    const char *p = s.c_str();
+    for (uint64_t i=0; i<dsize; i++)
+    {
+        vData.push_back(char2byte(p[2*i])*16 + char2byte(p[2*i + 1]));
+    }
+    return dsize;
 }
 
 void ba2string (string &s, const uint8_t *pData, uint64_t dataSize)
@@ -699,7 +716,7 @@ void sr4to8 ( Goldilocks &fr,
               Goldilocks::Element &r7 )
 {
     uint64_t aux;
-    
+
     aux = fr.toU64(a0);
     r0 = fr.fromU64( aux & 0xFFFFFFFF );
     r1 = fr.fromU64( aux >> 32 );

--- a/src/utils/scalar.hpp
+++ b/src/utils/scalar.hpp
@@ -75,6 +75,7 @@ string  byte2string(uint8_t b);
 uint64_t string2ba (const string &s, uint8_t *pData, uint64_t &dataSize);
 void     string2ba (const string &textString, string &baString);
 string   string2ba (const string &textString);
+uint64_t string2bv (const string &os, vector<uint8_t> &vData);
 void     ba2string (string &s, const uint8_t *pData, uint64_t dataSize);
 string   ba2string (const uint8_t *pData, uint64_t dataSize);
 void     ba2string (const string &baString, string &textString);

--- a/test/service/statedb/statedb_test_client.cpp
+++ b/test/service/statedb/statedb_test_client.cpp
@@ -42,22 +42,22 @@ void* stateDBTestClientThread (const Config& config)
         scalar2key(fr, keyScalar, key);
 
         value=2;
-        zkresult zkr = client->set(root, key, value, persistent, newRoot, &setResult);
+        zkresult zkr = client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         cout << "zkr=" << zkresult2string(zkr) << endl;
         zkassert(zkr==ZKR_SUCCESS);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        zkr = client->get(root, key, value, &getResult);
+        zkr = client->get(root, key, value, &getResult, NULL);
         cout << "zkr=" << zkresult2string(zkr) << endl;
         zkassert(zkr==ZKR_SUCCESS);
         value = getResult.value;
         zkassert(value==2);
 
         value=0;
-        zkr = client->set(root, key, value, persistent, newRoot, &setResult);
+        zkr = client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         cout << "zkr=" << zkresult2string(zkr) << endl;
-        zkassert(zkr==ZKR_SUCCESS);        
+        zkassert(zkr==ZKR_SUCCESS);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
 
@@ -80,18 +80,18 @@ void* stateDBTestClientThread (const Config& config)
         scalar2key(fr, keyScalar, key);
 
         value=2;
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         for (uint64_t i=0; i<4; i++) initialRoot[i] = root[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=3;
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=2;
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
@@ -118,22 +118,22 @@ void* stateDBTestClientThread (const Config& config)
         scalar2key(fr, keyScalar, key2);
 
         value=2;
-        client->set(root, key1, value, persistent, newRoot, &setResult);
+        client->set(root, key1, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=3;
-        client->set(root, key2, value, persistent, newRoot, &setResult);
+        client->set(root, key2, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=0;
 
-        client->set(root, key1, value, persistent, newRoot, &setResult);
+        client->set(root, key1, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        client->set(root, key2, value, persistent, newRoot, &setResult);
+        client->set(root, key2, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
 
@@ -158,22 +158,22 @@ void* stateDBTestClientThread (const Config& config)
         scalar2key(fr, keyScalar, key2);
 
         value=2;
-        client->set(root, key1, value, persistent, newRoot, &setResult);
+        client->set(root, key1, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=3;
-        client->set(root, key2, value, persistent, newRoot, &setResult);
+        client->set(root, key2, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=0;
 
-        client->set(root, key1, value, persistent, newRoot, &setResult);
+        client->set(root, key1, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        client->set(root, key2, value, persistent, newRoot, &setResult);
+        client->set(root, key2, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
 
@@ -202,33 +202,33 @@ void* stateDBTestClientThread (const Config& config)
         scalar2key(fr, keyScalar, key3);
 
         value=107;
-        client->set(root, key1, value, persistent, newRoot, &setResult);
-        
+        client->set(root, key1, value, persistent, newRoot, &setResult, NULL);
+
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=115;
-        client->set(root, key2, value, persistent, newRoot, &setResult);
+        client->set(root, key2, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=103;
-        client->set(root, key3, value, persistent, newRoot, &setResult);
+        client->set(root, key3, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=0;
 
-        client->set(root, key1, value, persistent, newRoot, &setResult);
+        client->set(root, key1, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        client->set(root, key2, value, persistent, newRoot, &setResult);
+        client->set(root, key2, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        client->set(root, key3, value, persistent, newRoot, &setResult);
-        
+        client->set(root, key3, value, persistent, newRoot, &setResult, NULL);
+
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
 
@@ -251,8 +251,8 @@ void* stateDBTestClientThread (const Config& config)
             keyScalar=i;
             scalar2key(fr, keyScalar, key);
             value = i + 1000;
-            client->set(root, key, value, persistent, newRoot, &setResult);
-            
+            client->set(root, key, value, persistent, newRoot, &setResult, NULL);
+
             for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
             zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
         }
@@ -262,8 +262,8 @@ void* stateDBTestClientThread (const Config& config)
         {
             keyScalar=i;
             scalar2key(fr, keyScalar, key);
-            client->set(root, key, value, persistent, newRoot, &setResult);
-            
+            client->set(root, key, value, persistent, newRoot, &setResult, NULL);
+
             for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         }
 
@@ -288,7 +288,7 @@ void* stateDBTestClientThread (const Config& config)
             keyScalar = i;
             scalar2key(fr, keyScalar, key);
             value = i + 1000;
-            client->set(root, key, value, persistent, newRoot, &setResult);
+            client->set(root, key, value, persistent, newRoot, &setResult, NULL);
             for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
             zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
         }
@@ -297,7 +297,7 @@ void* stateDBTestClientThread (const Config& config)
         {
             keyScalar = i;
             scalar2key(fr, keyScalar, key);
-            client->get(root, key, value, &getResult);
+            client->get(root, key, value, &getResult, NULL);
             zkassert(getResult.value==(i+1000));
         }
 
@@ -323,21 +323,21 @@ void* stateDBTestClientThread (const Config& config)
         keyScalar = 0; //0x00
         scalar2key(fr, keyScalar, key);
         value=2;
-        client->set(root, key, value, persistent, newRoot, &setResult);  
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar = 4369; //0x1111
         scalar2key(fr, keyScalar, key);
         value=2;
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar = 69905; //0x11111
         scalar2key(fr, keyScalar, key);
         value=3;
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
@@ -365,35 +365,35 @@ void* stateDBTestClientThread (const Config& config)
         keyScalar.set_str("56714103185361745016746792718676985000067748055642999311525839752090945477479", 10);
         value.set_str("8163644824788514136399898658176031121905718480550577527648513153802600646339", 10);
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar.set_str("980275562601266368747428591417466442501663392777380336768719359283138048405", 10);
         value.set_str("115792089237316195423570985008687907853269984665640564039457584007913129639934", 10);
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar.set_str("53001048207672216258532366725645107222481888169041567493527872624420899640125", 10);
         value.set_str("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10);
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar.set_str("60338373645545410525187552446039797737650319331856456703054942630761553352879", 10);
         value.set_str("7943875943875408", 10);
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar.set_str("56714103185361745016746792718676985000067748055642999311525839752090945477479", 10);
         value.set_str("35179347944617143021579132182092200136526168785636368258055676929581544372820", 10);
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
@@ -416,21 +416,21 @@ void* stateDBTestClientThread (const Config& config)
         keyScalar=1;
         value=2;
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar=2;
         value=3;
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         keyScalar=0x10000;
         value=0;
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
         zkassert(setResult.mode=="zeroToZero");
@@ -454,7 +454,7 @@ void* stateDBTestClientThread (const Config& config)
         keyScalar=1;
         value=2;
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
@@ -462,7 +462,7 @@ void* stateDBTestClientThread (const Config& config)
         keyScalar=0x10000;
         value=0;
         scalar2key(fr, keyScalar, key);
-        client->set(root, key, value, persistent, newRoot, &setResult);
+        client->set(root, key, value, persistent, newRoot, &setResult, NULL);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
         zkassert(setResult.mode=="zeroToZero");
@@ -473,8 +473,8 @@ void* stateDBTestClientThread (const Config& config)
 
     // It should add program data (setProgram) and retrieve it (getProgram)
     {
-        std::random_device rd;  
-        std::mt19937_64 gen(rd()); 
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
         std::uniform_int_distribution<unsigned long long> distrib(0, std::llround(std::pow(2,64)));
 
         Goldilocks::Element key[4]={0,0,0,0};
@@ -489,12 +489,12 @@ void* stateDBTestClientThread (const Config& config)
         }
 
         client->setProgram(key, in, true);
-        client->getProgram(key, out);
+        client->getProgram(key, out, NULL);
 
         for (uint8_t i=0; i<128; i++) {
             zkassert(in[i]==out[i]);
         }
-        
+
         cout << "StateDB client test 12 done" << endl;
     }
 

--- a/test/service/statedb/statedb_test_perf.cpp
+++ b/test/service/statedb/statedb_test_perf.cpp
@@ -53,8 +53,8 @@ void* stateDBPerfTestThread (const Config& config)
     pqxx::connection* pConnection = NULL;
 
     // Random generator
-    std::random_device rd;  
-    std::mt19937_64 gen(rd()); 
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
     std::uniform_int_distribution<unsigned long long> distrib(0, std::llround(std::pow(2,64)));
 
     try
@@ -69,11 +69,11 @@ void* stateDBPerfTestThread (const Config& config)
         cerr << "stateDBPerfTestThread: database.exception: " << e.what() << endl;
         if (pConnection!=NULL) delete pConnection;
         return NULL;
-    } 
+    }
 
     if (config.stateDBURL=="local") {
         cout << "Executing " << TEST_COUNT << " " << sTest << " operations using local client..." << endl;
-    } else {    
+    } else {
         cout << "Executing " << TEST_COUNT << " " << sTest << " operations using remote client..." << endl;
     }
 
@@ -82,15 +82,15 @@ void* stateDBPerfTestThread (const Config& config)
     for (uint64_t i=1; i<=TEST_COUNT; i++) {
         keyScalar = 0;
         for (int k=0; k<4; k++) {
-            r = distrib(gen); 
+            r = distrib(gen);
             keyScalar = (keyScalar << 64) + r;
         }
-    
+
         scalar2key(fr, keyScalar, key);
         value=i;
 
         #if PERF_TEST == PERF_SET
-            client->set(root, key, value, true, newRoot, &setResult);
+            client->set(root, key, value, true, newRoot, &setResult, NULL);
             for (int j=0; j<4; j++) root[j] = setResult.newRoot[j];
         #elif PERF_TEST == PERF_GET
             client->get(root, key, value, &getResult);
@@ -98,10 +98,10 @@ void* stateDBPerfTestThread (const Config& config)
     }
     #if PERF_TEST == PERF_SET
         if (config.dbAsyncWrite) client->flush();
-    #endif    
+    #endif
     uint64_t totalTimeUS = TimeDiff(tset);
 
-    #if PERF_TEST == PERF_SET  
+    #if PERF_TEST == PERF_SET
         cout << "Saving new root..." << endl;
         saveRoot (fr, pConnection, 100, root);
     #endif

--- a/test/sm/storage/storage_test.cpp
+++ b/test/sm/storage/storage_test.cpp
@@ -45,25 +45,25 @@ void StorageSM_UnitTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config &c
     mpz_class value = 10;
 
     // Get zero
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     cout << "0: StorageSMTest Get zero value=" << getResult.value.get_str(16) << endl;
 
     // Set insertNotFound
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="insertNotFound");
     cout << "1: StorageSMTest Set insertNotFound root=" << fea2string(fr, root) << " mode=" << setResult.mode <<endl;
 
     // Get non zero
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     cout << "2: StorageSMTest Get nonZero value=" << getResult.value.get_str(16) << endl;
 
     // Set deleteLast
     value=0;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="deleteLast");
@@ -71,54 +71,54 @@ void StorageSM_UnitTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config &c
 
     // Set insertNotFound
     value=10;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     cout << "4: StorageSMTest Set insertNotFound root=" << fea2string(fr, root) << " mode=" << setResult.mode <<endl;
 
     // Set update
     value=20;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="update");
     cout << "5: StorageSMTest Set update root=" << fea2string(fr, root) << " mode=" << setResult.mode << endl;
 
     // Get non zero
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     cout << "6: StorageSMTest Get nonZero value=" << getResult.value.get_str(16) << endl;
 
     // Set insertFound
     key[0] = fr.fromU64(3);
     value = 20;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="insertFound");
     cout << "7: StorageSMTest Set insertFound root=" << fea2string(fr, root) << " mode=" << setResult.mode << endl;
 
     // Get non zero
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     cout << "8: StorageSMTest Get nonZero value=" << getResult.value.get_str(16) << endl;
 
     // Set deleteFound
     value=0;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="deleteFound");
     cout << "9: StorageSMTest Set deleteFound root=" << fea2string(fr, root) << " mode=" << setResult.mode << endl;
 
     // Get zero
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     cout << "10: StorageSMTest Get zero value=" << getResult.value.get_str(16) << endl;
 
     // Set zeroToZzero
     value=0;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="zeroToZero");
@@ -126,14 +126,14 @@ void StorageSM_UnitTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config &c
 
     // Set insertFound
     value=40;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="insertFound");
     cout << "12: StorageSMTest Set insertFound root=" << fea2string(fr, root) << " mode=" << setResult.mode << endl;
-    
+
     // Get non zero
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     cout << "13: StorageSMTest Get nonZero value=" << getResult.value.get_str(16) << endl;
 
@@ -141,7 +141,7 @@ void StorageSM_UnitTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config &c
     key[0] = fr.zero();
     key[1] = fr.one();
     value=30;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="insertNotFound");
@@ -149,7 +149,7 @@ void StorageSM_UnitTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config &c
 
     // Set deleteNotFound
     value=0;
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="deleteNotFound");
@@ -166,9 +166,9 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
 {
     cout << "StorageSM_ZeroToZeroTest() starting..." << endl;
 
-    // It should add a zero value. Test 1 
+    // It should add a zero value. Test 1
     {
-        cout << "StorageSM_ZeroToZeroTest() Add zero value test 1. Testing..." << endl;    
+        cout << "StorageSM_ZeroToZeroTest() Add zero value test 1. Testing..." << endl;
         Smt smt(fr);
         Database db(fr);
         db.init(config);
@@ -179,7 +179,7 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         mpz_class value = 10;
 
         // Set insertNotFound
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(setResult.mode=="insertNotFound");
@@ -188,7 +188,7 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         key[0]=fr.zero();
         key[1]=fr.one();
         value=0;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(setResult.mode=="zeroToZero");
@@ -200,9 +200,9 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         cout << "StorageSM_ZeroToZeroTest() Add zero value test 1. Done" << endl;
     }
 
-    // It should add a zero value. Test 2 
+    // It should add a zero value. Test 2
     {
-        cout << "StorageSM_ZeroToZeroTest() Add zero value test 2. Testing..." << endl;  
+        cout << "StorageSM_ZeroToZeroTest() Add zero value test 2. Testing..." << endl;
         Smt smt(fr);
         Database db(fr);
         db.init(config);
@@ -213,14 +213,14 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         mpz_class value = 10;
 
         // Set insertNotFound
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(setResult.mode=="insertNotFound");
 
         // Set insertNotFound
         key[0] = fr.fromU64(0x13);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(setResult.mode=="insertFound");
@@ -228,7 +228,7 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         // Set zeroToZzero
         key[0] = fr.fromU64(0x73);
         value=0;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(setResult.mode=="zeroToZero");
@@ -242,7 +242,7 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
 
     // It should add a zero value in an empty tree
     {
-        cout << "StorageSM_ZeroToZeroTest() Add zero value in an empty tree. Testing..." << endl;        
+        cout << "StorageSM_ZeroToZeroTest() Add zero value in an empty tree. Testing..." << endl;
         Smt smt(fr);
         Database db(fr);
         db.init(config);
@@ -253,7 +253,7 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         mpz_class value = 0;
 
         //Set zero in an empty tree;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
@@ -266,7 +266,7 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
 
     // It should add a zero value with an intermediate node as sibling
     {
-        cout << "StorageSM_ZeroToZeroTest() Add a zero value with an intermediate node as sibling. Testing..." << endl;        
+        cout << "StorageSM_ZeroToZeroTest() Add a zero value with an intermediate node as sibling. Testing..." << endl;
         Smt smt(fr);
         Database db(fr);
         db.init(config);
@@ -276,34 +276,34 @@ void StorageSM_ZeroToZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Con
         Goldilocks::Element key[4]={0,1,0,0};
         mpz_class value = 10;
 
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
         key[0] = fr.one();
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
         key[2] = fr.one();
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
         key[1] = fr.zero();
         key[2] = fr.zero();
         value=0;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         zkassert(setResult.mode=="zeroToZero");
         zkassert(fr.equal(root[0],setResult.newRoot[0]) && fr.equal(root[1],setResult.newRoot[1]) &&
                  fr.equal(root[2],setResult.newRoot[2]) && fr.equal(root[3],setResult.newRoot[3]));
-        
+
         // Call storage state machine executor
         StorageExecutor storageExecutor(fr, poseidon, config);
         storageExecutor.execute(actionList.action);
 
-        cout << "StorageSM_ZeroToZeroTest() Add a zero value with an intermediate node as sibling. Done" << endl;        
+        cout << "StorageSM_ZeroToZeroTest() Add a zero value with an intermediate node as sibling. Done" << endl;
     }
 
     cout << "StorageSM_ZeroToZeroTest() done" << endl;
@@ -344,18 +344,18 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         scalar2key(fr, keyScalar, key);
 
         value=2;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        smt.get(db, root, key, getResult);
+        smt.get(db, root, key, getResult, NULL);
         actionList.addGetAction(getResult);
         value = getResult.value;
         zkassert(value==2);
 
         value=0;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
@@ -386,20 +386,20 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         scalar2key(fr, keyScalar, key);
 
         value=2;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         for (uint64_t i=0; i<4; i++) initialRoot[i] = root[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=3;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=2;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -434,25 +434,25 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         scalar2key(fr, keyScalar, key2);
 
         value=2;
-        smt.set(db, root, key1, value, false, setResult);
+        smt.set(db, root, key1, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=3;
-        smt.set(db, root, key2, value, false, setResult);
+        smt.set(db, root, key2, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=0;
 
-        smt.set(db, root, key1, value, false, setResult);
+        smt.set(db, root, key1, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        smt.set(db, root, key2, value, false, setResult);
+        smt.set(db, root, key2, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
@@ -485,25 +485,25 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         scalar2key(fr, keyScalar, key2);
 
         value=2;
-        smt.set(db, root, key1, value, false, setResult);
+        smt.set(db, root, key1, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=3;
-        smt.set(db, root, key2, value, false, setResult);
+        smt.set(db, root, key2, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=0;
 
-        smt.set(db, root, key1, value, false, setResult);
+        smt.set(db, root, key1, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        smt.set(db, root, key2, value, false, setResult);
+        smt.set(db, root, key2, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
@@ -539,36 +539,36 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         scalar2key(fr, keyScalar, key3);
 
         value=107;
-        smt.set(db, root, key1, value, false, setResult);
+        smt.set(db, root, key1, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=115;
-        smt.set(db, root, key2, value, false, setResult);
+        smt.set(db, root, key2, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=103;
-        smt.set(db, root, key3, value, false, setResult);
+        smt.set(db, root, key3, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         value=0;
 
-        smt.set(db, root, key1, value, false, setResult);
+        smt.set(db, root, key1, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        smt.set(db, root, key2, value, false, setResult);
+        smt.set(db, root, key2, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
-        smt.set(db, root, key3, value, false, setResult);
+        smt.set(db, root, key3, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(fr.isZero(root[0]) && fr.isZero(root[1]) && fr.isZero(root[2]) && fr.isZero(root[3]));
@@ -600,7 +600,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
             keyScalar=i;
             scalar2key(fr, keyScalar, key);
             value = i + 1000;
-            smt.set(db, root, key, value, false, setResult);
+            smt.set(db, root, key, value, false, setResult, NULL);
             actionList.addSetAction(setResult);
             for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
             zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -611,7 +611,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         {
             keyScalar=i;
             scalar2key(fr, keyScalar, key);
-            smt.set(db, root, key, value, false, setResult);
+            smt.set(db, root, key, value, false, setResult, NULL);
             actionList.addSetAction(setResult);
             for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         }
@@ -644,7 +644,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
             keyScalar = i;
             scalar2key(fr, keyScalar, key);
             value = i + 1000;
-            smt.set(db, root, key, value, false, setResult);
+            smt.set(db, root, key, value, false, setResult, NULL);
             actionList.addSetAction(setResult);
             for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
             zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -654,7 +654,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         {
             keyScalar = i;
             scalar2key(fr, keyScalar, key);
-            smt.get(db, root, key, getResult);
+            smt.get(db, root, key, getResult, NULL);
             actionList.addGetAction(getResult);
             zkassert(getResult.value==(i+1000));
         }
@@ -688,7 +688,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar = 0; //0x00
         scalar2key(fr, keyScalar, key);
         value=2;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -696,7 +696,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar = 4369; //0x1111
         scalar2key(fr, keyScalar, key);
         value=2;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -704,13 +704,13 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar = 69905; //0x11111
         scalar2key(fr, keyScalar, key);
         value=3;
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         zkassert(fr.equal(root[0], expectedRoot[0]) && fr.equal(root[1], expectedRoot[1]) && fr.equal(root[2], expectedRoot[2]) && fr.equal(root[3], expectedRoot[3]));
-        
+
         // Call storage state machine executor
         StorageExecutor storageExecutor(fr, poseidon, config);
         storageExecutor.execute(actionList.action);
@@ -739,7 +739,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar.set_str("56714103185361745016746792718676985000067748055642999311525839752090945477479", 10);
         value.set_str("8163644824788514136399898658176031121905718480550577527648513153802600646339", 10);
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -747,7 +747,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar.set_str("980275562601266368747428591417466442501663392777380336768719359283138048405", 10);
         value.set_str("115792089237316195423570985008687907853269984665640564039457584007913129639934", 10);
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -756,7 +756,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar.set_str("53001048207672216258532366725645107222481888169041567493527872624420899640125", 10);
         value.set_str("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10);
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -764,7 +764,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar.set_str("60338373645545410525187552446039797737650319331856456703054942630761553352879", 10);
         value.set_str("7943875943875408", 10);
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -773,13 +773,13 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar.set_str("56714103185361745016746792718676985000067748055642999311525839752090945477479", 10);
         value.set_str("35179347944617143021579132182092200136526168785636368258055676929581544372820", 10);
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
 
         zkassert(fr.equal(root[0], expectedRoot[0]) && fr.equal(root[1], expectedRoot[1]) && fr.equal(root[2], expectedRoot[2]) && fr.equal(root[3], expectedRoot[3]));
-        
+
         // Call storage state machine executor
         StorageExecutor storageExecutor(fr, poseidon, config);
         storageExecutor.execute(actionList.action);
@@ -804,7 +804,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar=1;
         value=2;
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -812,7 +812,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar=2;
         value=3;
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -820,7 +820,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar=0x10000;
         value=0;
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
@@ -851,7 +851,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar=1;
         value=2;
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
         zkassert(!fr.isZero(root[0]) || !fr.isZero(root[1]) || !fr.isZero(root[2]) || !fr.isZero(root[3]));
@@ -859,7 +859,7 @@ void StorageSM_UseCaseTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
         keyScalar=0x10000;
         value=0;
         scalar2key(fr, keyScalar, key);
-        smt.set(db, root, key, value, false, setResult);
+        smt.set(db, root, key, value, false, setResult, NULL);
         actionList.addSetAction(setResult);
         for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
 
@@ -891,7 +891,7 @@ void StorageSM_GetZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
     mpz_class value = 10;
 
     // Set insertNotFound
-    smt.set(db, root, key, value, false, setResult);
+    smt.set(db, root, key, value, false, setResult, NULL);
     actionList.addSetAction(setResult);
     for (uint64_t i=0; i<4; i++) root[i] = setResult.newRoot[i];
     zkassert(setResult.mode=="insertNotFound");
@@ -900,7 +900,7 @@ void StorageSM_GetZeroTest (Goldilocks &fr, PoseidonGoldilocks &poseidon, Config
     // Get zero
     key[0]=fr.zero();
     key[1]=fr.one();
-    smt.get(db, root, key, getResult);
+    smt.get(db, root, key, getResult, NULL);
     actionList.addGetAction(getResult);
     for (uint64_t i=0; i<4; i++) root[i] = getResult.root[i];
     cout << "1: StorageSM_GetZeroTest Get root=" << fea2string(fr, root) << " value=" << getResult.value.get_str(16) << endl;

--- a/testvectors/config.json
+++ b/testvectors/config.json
@@ -25,6 +25,7 @@
     "useMainExecGenerated": false,
     "saveInputToFile": false,
     "saveDbReadsToFile": false,
+    "saveDbReadsToFileOnChange": false,
     "saveOutputToFile": false,
     "opcodeTracer": false,
     "logRemoteDbReads": false,


### PR DESCRIPTION
Added some inprovements to the StateDB module:

- DB read log (stored in the output file) is managed now directly by the StateDB class (instead to use directly the Database class that is not threadsafe)
- DB read log is supported also when executor/prover is using the remote StateDB service (until now it was only supported when using local StateDB)
- New config paramater "saveDbReadsToFileOnChange". Enabling this parameter, when using StateDB local, the DB read log data is stored in the outputfile each time a DB read is performed. When using StateDB remote service, the DB read log is stored each time a remote SMT set/get operation si performed. With this new config param, in scenarios where we have a executor crash, we can have an output file with the DB read log data generated before the crash.
- Fixed SQL DB space usage for storing MT nodes or program data. We now use a string of 16 hex characters to store an FE (instead of 64 characters), and we also use a string of 2 hex characters to store each byte of program data (instead of 64 hex characters for each byte that we used before). This change "breaks" compatibility with data stored in a database by previous versions of the prover/executor. When running this new version we need to "clear" the databases and start from the scratch