### PR TITLE
Added support for building the docker image for arm64

### DIFF
--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -52,7 +52,7 @@ jobs:
             dbg=${{ steps.setvars.outputs.dbg }}
           context: .
           file: Dockerfile-GHA
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             hermeznetwork/zkevm-prover:${{ steps.setvars.outputs.sha_short }}


### PR DESCRIPTION
This will enable Apple M1 users to also be able to run the prover image.
**Important**: I've no way of testing this as you guys have a very special build machine and I don't know the exact params of it.