### PR TITLE
Fix the key runFile

### DIFF
--- a/testvectors/config.json
+++ b/testvectors/config.json
@@ -10,7 +10,7 @@
     "runStateDBServer": true,
     "runStateDBTest": false,
 
-    "runFile": false,
+    "runFileGenProof": false,
     "runFileFast": false,
     "runFileFastMultithread": false,
 


### PR DESCRIPTION
Config file should use one of the keys as defined in src/config/config.hpp

bool runFileGenProof;                   // Full proof = Executor + Stark + StarkC12a + StarkC12b + Groth16 (Snark)
bool runFileGenBatchProof;              // Proof of 1 batch = Executor + Stark + StarkC12a
bool runFileGenAggregatedProof;         // Proof of 2 batches = StarckC12a (of the 2 batches StarkC12a)
bool runFileGenFinalProof;              // Final proof of an aggregated proof = StarkC12b + Groth16 (Snark)
bool runFileProcessBatch;               // Executor (only main SM)
bool runFileProcessBatchMultithread;    // Executor (only main SM) in parallel