### PR TITLE
Avoid unnecessary reset in constructors

### DIFF
--- a/src/prover/prover.cpp
+++ b/src/prover/prover.cpp
@@ -930,9 +930,11 @@ void Prover::execute(ProverRequest *pProverRequest)
     // Save commit pols to file zkevm.commit
     if (config.zkevmCmPolsAfterExecutor != "")
     {
+        TimerStart(PROVER_EXECUTE_SAVE_COMMIT_POLS_AFTER_EXECUTOR);
         void *pointerCmPols = mapFile(config.zkevmCmPolsAfterExecutor, cmPols.size(), true);
         memcpy(pointerCmPols, cmPols.address(), cmPols.size());
         unmapFile(pointerCmPols, cmPols.size());
+        TimerStopAndLog(PROVER_EXECUTE_SAVE_COMMIT_POLS_AFTER_EXECUTOR);
     }
 
     /***************/

--- a/src/sm/arith/arith_action_bytes.hpp
+++ b/src/sm/arith/arith_action_bytes.hpp
@@ -34,28 +34,6 @@ public:
     uint64_t _q0[16];
     uint64_t _q1[16];
     uint64_t _q2[16];
-
-    ArithActionBytes()
-    {
-        selEq0 = 0;
-        selEq1 = 0;
-        selEq2 = 0;
-        selEq3 = 0;
-        memset(_x1, 0, sizeof(_x1));
-        memset(_y1, 0, sizeof(_y1));
-        memset(_x2, 0, sizeof(_x2));
-        memset(_y2, 0, sizeof(_y2));
-        memset(_x3, 0, sizeof(_x3));
-        memset(_x3, 0, sizeof(_y3));
-        memset(_selEq0, 0, sizeof(_selEq0));
-        memset(_selEq1, 0, sizeof(_selEq1));
-        memset(_selEq2, 0, sizeof(_selEq2));
-        memset(_selEq3, 0, sizeof(_selEq3));
-        memset(_s, 0, sizeof(_s));
-        memset(_q0, 0, sizeof(_q0));
-        memset(_q1, 0, sizeof(_q1));
-        memset(_q2, 0, sizeof(_q2));
-    }
 };
 
 #endif

--- a/src/sm/arith/arith_executor.cpp
+++ b/src/sm/arith/arith_executor.cpp
@@ -28,6 +28,7 @@ void ArithExecutor::execute (vector<ArithAction> &action, ArithCommitPols &pols)
     {
         uint64_t dataSize;
         ArithActionBytes actionBytes;
+
         actionBytes.x1 = action[i].x1;
         actionBytes.y1 = action[i].y1;
         actionBytes.x2 = action[i].x2;
@@ -38,6 +39,7 @@ void ArithExecutor::execute (vector<ArithAction> &action, ArithCommitPols &pols)
         actionBytes.selEq1 = action[i].selEq1;
         actionBytes.selEq2 = action[i].selEq2;
         actionBytes.selEq3 = action[i].selEq3;
+
         dataSize = 16;
         scalar2ba16(actionBytes._x1, dataSize, action[i].x1);
         dataSize = 16;
@@ -58,6 +60,12 @@ void ArithExecutor::execute (vector<ArithAction> &action, ArithCommitPols &pols)
         scalar2ba16(actionBytes._selEq2, dataSize, action[i].selEq2);
         dataSize = 16;
         scalar2ba16(actionBytes._selEq3, dataSize, action[i].selEq3);
+
+        memset(actionBytes._s, 0, sizeof(actionBytes._s));
+        memset(actionBytes._q0, 0, sizeof(actionBytes._q0));
+        memset(actionBytes._q1, 0, sizeof(actionBytes._q1));
+        memset(actionBytes._q2, 0, sizeof(actionBytes._q2));
+
         input.push_back(actionBytes);
     }
 

--- a/src/sm/binary/binary_action_bytes.hpp
+++ b/src/sm/binary/binary_action_bytes.hpp
@@ -11,15 +11,6 @@ public:
     uint8_t c_bytes[32];
     uint64_t opcode;
     uint64_t type;
-
-    BinaryActionBytes()
-    {
-        memset(a_bytes, 0, 32);
-        memset(b_bytes, 0, 32);
-        memset(b_bytes, 0, 32);
-        opcode = 0;
-        type = 0;
-    }
 };
 
 #endif

--- a/src/sm/binary/binary_executor.cpp
+++ b/src/sm/binary/binary_executor.cpp
@@ -101,14 +101,12 @@ void BinaryExecutor::execute (vector<BinaryAction> &action, BinaryCommitPols &po
     }
 
     // Local array of N uint32
-    uint32_t * c0Temp;
-    c0Temp = (uint32_t *)malloc(N*sizeof(uint32_t));
+    uint32_t * c0Temp = (uint32_t *)calloc(N*sizeof(uint32_t),1);
     if (c0Temp == NULL)
     {
         cerr << "Error: BinaryExecutor::execute() failed calling malloc() for c0Temp" << endl;
         exitProcess();
     }
-    memset(c0Temp, 0, N*sizeof(uint32_t));
 
     // Process all the inputs
 //#pragma omp parallel for // TODO: Disabled since OMP decreases performance, probably due to cache invalidations


### PR DESCRIPTION
Performance optimizations in binary and arith executor initialization.
Add traces to save commit pols after executor, since this operation can take up to a minute in debug.