### PR TITLE
DB Cache improvements

### DIFF
--- a/config/config_executor.json
+++ b/config/config_executor.json
@@ -37,6 +37,10 @@
     "saveFilesInSubfolders": false,
     
     "loadDBToMemCache": true,
+    "loadDBToMemCacheInParallel": false,
+    "dbMTCacheSize": 16384,
+    "dbProgramCacheSize": 16384,
+
     "opcodeTracer": false,
     "logRemoteDbReads": false,
     "logExecutorServerResponses": false,

--- a/config/config_prover.json
+++ b/config/config_prover.json
@@ -37,6 +37,10 @@
     "saveFilesInSubfolders": false,
     
     "loadDBToMemCache": true,
+    "loadDBToMemCacheInParallel": false,
+    "dbMTCacheSize": 16384,
+    "dbProgramCacheSize": 16384,
+    
     "opcodeTracer": false,
     "logRemoteDbReads": false,
     "logExecutorServerResponses": false,

--- a/config/config_statedb.json
+++ b/config/config_statedb.json
@@ -37,6 +37,10 @@
     "saveFilesInSubfolders": false,
     
     "loadDBToMemCache": true,
+    "loadDBToMemCacheInParallel": false,
+    "dbMTCacheSize": 16384,
+    "dbProgramCacheSize": 16384,
+
     "opcodeTracer": false,
     "logRemoteDbReads": false,
     "logExecutorServerResponses": false,

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -143,6 +143,18 @@ void Config::load(json &config)
     if (config.contains("loadDBToMemCache") && config["loadDBToMemCache"].is_boolean())
         loadDBToMemCache = config["loadDBToMemCache"];
 
+    loadDBToMemCacheInParallel = false;
+    if (config.contains("loadDBToMemCacheInParallel") && config["loadDBToMemCacheInParallel"].is_boolean())
+        loadDBToMemCacheInParallel = config["loadDBToMemCacheInParallel"];
+
+    dbMTCacheSize = 0;
+    if (config.contains("dbMTCacheSize") && config["dbMTCacheSize"].is_number())
+        dbMTCacheSize = config["dbMTCacheSize"];
+
+    dbProgramCacheSize = 0;
+    if (config.contains("dbProgramCacheSize") && config["dbProgramCacheSize"].is_number())
+        dbProgramCacheSize = config["dbProgramCacheSize"];
+
     opcodeTracer = false;
     if (config.contains("opcodeTracer") && config["opcodeTracer"].is_boolean())
         opcodeTracer = config["opcodeTracer"];
@@ -478,6 +490,8 @@ void Config::print(void)
         cout << "    saveResponseToFile=true" << endl;
     if (loadDBToMemCache)
         cout << "    loadDBToMemCache=true" << endl;
+    if (loadDBToMemCacheInParallel)
+        cout << "    loadDBToMemCacheInParallel=true" << endl;
     if (opcodeTracer)
         cout << "    opcodeTracer=true" << endl;
     if (logRemoteDbReads)
@@ -538,4 +552,6 @@ void Config::print(void)
     cout << "    maxExecutorThreads=" << maxExecutorThreads << endl;
     cout << "    maxProverThreads=" << maxProverThreads << endl;
     cout << "    maxStateDBThreads=" << maxStateDBThreads << endl;
+    cout << "    dbMTCacheSize=" << dbMTCacheSize << endl;
+    cout << "    dbProgramCacheSize=" << dbProgramCacheSize << endl;
 }

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -51,6 +51,9 @@ public:
     bool saveFilesInSubfolders; // Saves output files in folders per hour, e.g. output/2023/01/10/18
 
     bool loadDBToMemCache;
+    bool loadDBToMemCacheInParallel;
+    int64_t dbMTCacheSize; // Size in MBytes for the cache to store MT records
+    int64_t dbProgramCacheSize; // Size in MBytes for the cache to store Program (SC) records
     bool opcodeTracer;
     bool logRemoteDbReads;
     bool logExecutorServerResponses;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,8 +526,8 @@ int main(int argc, char **argv)
     /* INIT DB CACHE */
     if (config.databaseURL != "local") // remote DB
     {
-        Database::dbMTCache.setCacheSize(config.dbMTCacheSize*(int64_t)1024*(int64_t)1024);
-        Database::dbProgramCache.setCacheSize(config.dbProgramCacheSize*(int64_t)1024*(int64_t)1024);
+        Database::dbMTCache.setCacheSize(config.dbMTCacheSize*1024*1024);
+        Database::dbProgramCache.setCacheSize(config.dbProgramCacheSize*1024*1024);
 
         if (config.loadDBToMemCache && (config.runAggregatorClient || config.runExecutorServer || config.runStateDBServer))
         {        

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -524,11 +524,32 @@ int main(int argc, char **argv)
     TimerStopAndLog(PROVER_CONSTRUCTOR);
 
     /* INIT DB CACHE */
-    if (config.loadDBToMemCache && (config.runAggregatorClient || config.runExecutorServer || config.runStateDBServer))
+    if (config.databaseURL != "local") // remote DB
     {
-        StateDB stateDB(fr, config);
-        stateDB.loadDB2MemCache();
-    }
+        Database::dbMTCache.setCacheSize(config.dbMTCacheSize*(int64_t)1024*(int64_t)1024);
+        Database::dbProgramCache.setCacheSize(config.dbProgramCacheSize*(int64_t)1024*(int64_t)1024);
+
+        if (config.loadDBToMemCache && (config.runAggregatorClient || config.runExecutorServer || config.runStateDBServer))
+        {        
+            // if we have a db cache enabled
+            if ((Database::dbMTCache.enabled()) || (Database::dbProgramCache.enabled()))
+            {
+                if (config.loadDBToMemCacheInParallel) {
+                    // Run thread that loads the DB into the dbCache
+                    std::thread loadDBThread (loadDb2MemCache, config);
+                    loadDBThread.detach();
+                } else {
+                    loadDb2MemCache(config);
+                }
+            }
+        }
+    } 
+    else 
+    {
+        // set no limit for the db caches as we are using local (in memory) db
+        Database::dbMTCache.setCacheSize(-1); 
+        Database:: dbProgramCache.setCacheSize(-1);
+    }    
 
     /* SERVERS */
 

--- a/src/service/statedb/statedb.cpp
+++ b/src/service/statedb/statedb.cpp
@@ -85,13 +85,6 @@ void StateDB::loadProgramDB(const DatabaseMap::ProgramMap &input, const bool per
     }
 }
 
-void StateDB::loadDB2MemCache()
-{
-    lock_guard<recursive_mutex> guard(mlock);
-
-    db.loadDB2MemCache();
-}
-
 void StateDB::flush()
 {
     lock_guard<recursive_mutex> guard(mlock);

--- a/src/service/statedb/statedb.hpp
+++ b/src/service/statedb/statedb.hpp
@@ -25,7 +25,6 @@ public:
     zkresult getProgram(const Goldilocks::Element (&key)[4], vector<uint8_t> &data, DatabaseMap *dbReadLog);
     void loadDB(const DatabaseMap::MTMap &inputDB, const bool persistent);
     void loadProgramDB(const DatabaseMap::ProgramMap &inputProgramDB, const bool persistent);
-    void loadDB2MemCache();
     void flush();
 
     // Methods added for testing purposes

--- a/src/statedb/database.cpp
+++ b/src/statedb/database.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <thread>
 #include "database.hpp"
 #include "config.hpp"
 #include "scalar.hpp"
@@ -6,12 +7,24 @@
 #include "definitions.hpp"
 #include "zkresult.hpp"
 #include "utils.hpp"
+#include <unistd.h>
+#include "timer.hpp"
 
-// Create static Database::dbCache object. This will be used to store DB records in memory
-// and it will be shared for all the instances of Database class. DatabaseMap class is thread-safe
-DatabaseMap Database::dbCache;
-bool Database::dbLoaded2Cache = false;
+// Create static Database::dbMTCache and DatabaseCacheProgram objects
+// This will be used to store DB records in memory and it will be shared for all the instances of Database class
+// DatabaseCacheMT and DatabaseCacheProgram classes are thread-safe
+DatabaseMTCache Database::dbMTCache;
+DatabaseProgramCache Database::dbProgramCache;
 
+
+// Helper functions
+string removeBSXIfExists(string s) {return ((s.at(0) == '\\') && (s.at(1) == 'x')) ? s.substr(2) : s;}
+void string2fea(Goldilocks &fr, const string os, vector<Goldilocks::Element> &fea);
+void string2ba(Goldilocks &fr, const string os, vector<uint8_t> &data);
+void* asyncDatabaseWriteThread(void* arg);
+void loadDb2MemCache(const Config config);
+
+// Database class implementation
 void Database::init(const Config &_config)
 {
     // Check that it has not been initialized before
@@ -22,6 +35,9 @@ void Database::init(const Config &_config)
     }
 
     config = _config;
+
+    useDBMTCache = dbMTCache.enabled();
+    useDBProgramCache = dbProgramCache.enabled();
 
     // Configure the server, if configuration is provided
     if (config.databaseURL != "local")
@@ -50,7 +66,7 @@ zkresult Database::read(const string &_key, vector<Goldilocks::Element> &value, 
     key = stringToLower(key);
 
     // If the key is found in local database (cached) simply return it
-    if (Database::dbCache.findMT(key, value))
+    if ((useDBMTCache) && (Database::dbMTCache.find(key, value)))
     {
         // Add to the read log
         if (dbReadLog != NULL) dbReadLog->add(key, value);
@@ -64,10 +80,10 @@ zkresult Database::read(const string &_key, vector<Goldilocks::Element> &value, 
         r = readRemote(config.dbNodesTableName, key, sData);
         if (r == ZKR_SUCCESS)
         {
-            string2fea(sData, value);
+            string2fea(fr, sData, value);
 
             // Store it locally to avoid any future remote access for this key
-            Database::dbCache.add(key, value);
+            if (useDBMTCache) Database::dbMTCache.add(key, value);
 
             // Add to the read log
             if (dbReadLog != NULL) dbReadLog->add(key, value);
@@ -122,10 +138,10 @@ zkresult Database::write(const string &_key, const vector<Goldilocks::Element> &
     }
     else r = ZKR_SUCCESS;
 
-    if (r == ZKR_SUCCESS)
+    if ((r == ZKR_SUCCESS) && (useDBMTCache))
     {
         // Create in memory cache
-        Database::dbCache.add(key, value);
+        Database::dbMTCache.add(key, value);
     }
 
 #ifdef LOG_DB_WRITE
@@ -283,10 +299,10 @@ zkresult Database::setProgram(const string &_key, const vector<uint8_t> &data, c
     }
     else r = ZKR_SUCCESS;
 
-    if (r == ZKR_SUCCESS)
+    if ((r == ZKR_SUCCESS) && (useDBProgramCache))
     {
         // Create in memory cache
-        Database::dbCache.add(key, data);
+        Database::dbProgramCache.add(key, data);
     }
 
 #ifdef LOG_DB_WRITE
@@ -320,7 +336,7 @@ zkresult Database::getProgram(const string &_key, vector<uint8_t> &data, Databas
     key = stringToLower(key);
 
     // If the key is found in local database (cached) simply return it
-    if (Database::dbCache.findProgram(key, data))
+    if ((useDBProgramCache) && (Database::dbProgramCache.find(key, data)))
     {
         // Add to the read log
         if (dbReadLog != NULL) dbReadLog->add(key, data);
@@ -335,10 +351,10 @@ zkresult Database::getProgram(const string &_key, vector<uint8_t> &data, Databas
         if (r == ZKR_SUCCESS)
         {
             //String to byte/uint8_t vector
-            string2ba(sData, data);
+            string2ba(fr, sData, data);
 
             // Store it locally to avoid any future remote access for this key
-            Database::dbCache.add(key, data);
+            if (useDBProgramCache) Database::dbProgramCache.add(key, data);
 
             // Add to the read log
             if (dbReadLog != NULL) dbReadLog->add(key, data);
@@ -362,109 +378,6 @@ zkresult Database::getProgram(const string &_key, vector<uint8_t> &data, Databas
 #endif
 
     return r;
-}
-
-void Database::string2fea(const string os, vector<Goldilocks::Element> &fea)
-{
-    Goldilocks::Element fe;
-    for (uint64_t i = 0; i < os.size(); i += 16)
-    {
-        if (i + 16 > os.size())
-        {
-            cerr << "Error: Database::string2fea() found incorrect DATA column size: " << os.size() << endl;
-            exitProcess();
-        }
-        string2fe(fr, os.substr(i, 16), fe);
-        fea.push_back(fe);
-    }
-}
-
-void Database::string2ba(const string os, vector<uint8_t> &data)
-{
-    string s = Remove0xIfPresent(os);
-
-    if (s.size()%2 != 0)
-    {
-        s = "0" + s;
-    }
-
-    uint64_t dsize = s.size()/2;
-    const char *p = s.c_str();
-    for (uint64_t i=0; i<dsize; i++)
-    {
-        data.push_back(char2byte(p[2*i])*16 + char2byte(p[2*i + 1]));
-    }
-}
-
-void Database::loadDB2MemCache()
-{
-    if (!useRemoteDB) return;
-
-    if (Database::dbLoaded2Cache) return;
-
-    cout << "Loading SQL Database to memory cache..." << endl;
-
-    try
-    {
-        // Start a transaction.
-        pqxx::nontransaction n(*pConnectionRead);
-
-        // Prepare the query
-        string query = "SELECT * FROM " + config.dbNodesTableName +";";
-
-        // Execute the query
-        pqxx::result rows = n.exec(query);
-
-        for (pqxx::result::size_type i=0; i < rows.size(); i++)
-        {
-            vector<Goldilocks::Element> value;
-
-            string2fea(removeBSXIfExists(rows[i][1].c_str()), value);
-
-            Database::dbCache.add(removeBSXIfExists(rows[i][0].c_str()), value);
-        }
-
-        // Commit your transaction
-        n.commit();
-    }
-    catch (const std::exception &e)
-    {
-        cerr << "Error: Database::loadDB2MemCache() table=" << config.dbNodesTableName << " exception: " << e.what() << endl;
-        exitProcess();
-    }
-
-    try
-    {
-        // Start a transaction.
-        pqxx::nontransaction n(*pConnectionRead);
-
-        // Prepare the query
-        string query = "SELECT * FROM " + config.dbProgramTableName +";";
-
-        // Execute the query
-        pqxx::result rows = n.exec(query);
-
-        for (pqxx::result::size_type i=0; i < rows.size(); i++)
-        {
-            vector<uint8_t> value;
-
-            string2ba(removeBSXIfExists(rows[i][1].c_str()), value);
-
-            Database::dbCache.add(removeBSXIfExists(rows[i][0].c_str()), value);
-        }
-
-        // Commit your transaction
-        n.commit();
-    }
-    catch (const std::exception &e)
-    {
-        cerr << "Error: Database::loadDB2MemCache() table=" << config.dbProgramTableName << " exception: " << e.what() << endl;
-        exitProcess();
-    }
-
-    Database::dbLoaded2Cache = true;
-    
-    cout << "Load done" << endl;        
 }
 
 void Database::addWriteQueue(const string sqlWrite)
@@ -505,6 +418,7 @@ void Database::commit()
 
 void Database::processWriteQueue()
 {
+    //TODO: Review implementation of this function. The code should be directly in the thread function
     string writeQuery;
 
     cout << "Database::processWriteQueue() started" << endl;
@@ -574,16 +488,17 @@ void Database::processWriteQueue()
 
 void Database::print(void)
 {
-    DatabaseMap::MTMap mtDB = Database::dbCache.getMTDB();
-    cout << "Database of " << mtDB.size() << " elements:" << endl;
-    for (DatabaseMap::MTMap::iterator it = mtDB.begin(); it != mtDB.end(); it++)
-    {
-        vector<Goldilocks::Element> vect = it->second;
-        cout << "key:" << it->first << " ";
-        for (uint64_t i = 0; i < vect.size(); i++)
-            cout << fr.toString(vect[i], 16) << ":";
-        cout << endl;
-    }
+    // TODO: Update implementation
+    // DatabaseMap::MTMap mtDB = Database::dbCache.getMTDB();
+    // cout << "Database of " << mtDB.size() << " elements:" << endl;
+    // for (DatabaseMap::MTMap::iterator it = mtDB.begin(); it != mtDB.end(); it++)
+    // {
+    //     vector<Goldilocks::Element> vect = it->second;
+    //     cout << "key:" << it->first << " ";
+    //     for (uint64_t i = 0; i < vect.size(); i++)
+    //         cout << fr.toString(vect[i], 16) << ":";
+    //     cout << endl;
+    // }
 }
 
 void Database::printTree(const string &root, string prefix)
@@ -691,9 +606,145 @@ Database::~Database()
     }
 }
 
+void string2fea(Goldilocks &fr, const string os, vector<Goldilocks::Element> &fea)
+{
+    Goldilocks::Element fe;
+    for (uint64_t i = 0; i < os.size(); i += 16)
+    {
+        if (i + 16 > os.size())
+        {
+            cerr << "Error: Database::string2fea() found incorrect DATA column size: " << os.size() << endl;
+            exitProcess();
+        }
+        string2fe(fr, os.substr(i, 16), fe);
+        fea.push_back(fe);
+    }
+}
+
+void string2ba(Goldilocks &fr, const string os, vector<uint8_t> &data)
+{
+    string s = Remove0xIfPresent(os);
+
+    if (s.size()%2 != 0)
+    {
+        s = "0" + s;
+    }
+
+    uint64_t dsize = s.size()/2;
+    const char *p = s.c_str();
+    for (uint64_t i=0; i<dsize; i++)
+    {
+        data.push_back(char2byte(p[2*i])*16 + char2byte(p[2*i + 1]));
+    }
+}
+
 void *asyncDatabaseWriteThread(void *arg)
 {
     Database *db = (Database *)arg;
     db->processWriteQueue();
     return NULL;
+}
+
+void loadDb2MemCache(const Config config)
+{
+    TimerStart(LOAD_DB_TO_CACHE);
+    
+    Goldilocks fr;
+    pqxx::connection *pConnection = NULL;
+
+    try
+    {
+        // Create the database connection
+        pConnection = new pqxx::connection{config.databaseURL};
+    }
+    catch(const std::exception& e)
+    {
+        cerr << "Error: Database::loadDb2MemCache() exception: " << e.what() << endl;
+        exitProcess();
+    }
+
+    try
+    {
+        if (config.dbMTCacheSize > 0) 
+        {
+            // Start a transaction.
+            pqxx::nontransaction n(*pConnection);
+
+            // Prepare the query
+            string query = "SELECT * FROM " + config.dbNodesTableName +";";
+
+            // Execute the query
+            pqxx::result rows = n.exec(query);
+            pqxx::result::size_type i;
+            uint64_t count = 0;
+            for (i=0; i < rows.size(); i++)
+            {
+                count++;
+                vector<Goldilocks::Element> value;
+                string2fea(fr, removeBSXIfExists(rows[i][1].c_str()), value);
+
+                if (Database::dbMTCache.add(removeBSXIfExists(rows[i][0].c_str()), value))
+                {
+                    // Cache is full stop loading records
+                    cout << "MT cache full, stop loading records" << endl;
+                    break;
+                }
+            }
+
+            cout << "MT cache loaded. Count=" << count << endl;
+
+            // Commit your transaction
+            n.commit();
+        }
+    }
+    catch (const std::exception &e)
+    {
+        cerr << "Error: Database::loadDb2MemCache() table=" << config.dbNodesTableName << " exception: " << e.what() << endl;
+        exitProcess();
+    }
+
+    try
+    {
+        if (config.dbProgramCacheSize)
+        {
+            // Start a transaction.
+            pqxx::nontransaction n(*pConnection);
+
+            // Prepare the query
+            string query = "SELECT * FROM " + config.dbProgramTableName +";";
+
+            // Execute the query
+            pqxx::result rows = n.exec(query);
+            pqxx::result::size_type i = 0;
+            uint64_t count = 0;
+            for (i=0; i < rows.size(); i++)
+            {
+                count++;
+                vector<uint8_t> value;
+                string2ba(fr, removeBSXIfExists(rows[i][1].c_str()), value);
+
+                if (Database::dbProgramCache.add(removeBSXIfExists(rows[i][0].c_str()), value))
+                {
+                    // Cache is full stop loading records
+                    cout << "Program cache full, stop loading records" << endl;
+                    break;
+                }
+            }
+
+            cout << "Program cache loaded. Count=" << count << endl;
+
+            // Commit your transaction
+            n.commit();
+        }
+    }
+    catch (const std::exception &e)
+    {
+        cerr << "Error: Database::loadDb2MemCache() table=" << config.dbProgramTableName << " exception: " << e.what() << endl;
+        exitProcess();
+    }
+
+    if (pConnection != NULL)
+        delete pConnection;
+
+    TimerStopAndLog(LOAD_DB_TO_CACHE);
 }

--- a/src/statedb/database.hpp
+++ b/src/statedb/database.hpp
@@ -10,6 +10,7 @@
 #include <semaphore.h>
 #include "zkresult.hpp"
 #include "database_map.hpp"
+#include "database_cache.hpp"
 
 using namespace std;
 
@@ -23,6 +24,8 @@ private:
     bool asyncWrite = false;
     bool bInitialized = false;
     bool useRemoteDB = false;
+    bool useDBMTCache = false;
+    bool useDBProgramCache = false;
     Config config;
     pthread_t writeThread;
     vector<string> writeQueue;
@@ -39,15 +42,12 @@ private:
     void initRemote(void);
     zkresult readRemote(const string tableName, const string &key, string &value);
     zkresult writeRemote(const string tableName, const string &key, const string &value);
-    void string2fea(const string os, vector<Goldilocks::Element> &fea);
-    void string2ba(const string os, vector<uint8_t> &data);
-    string removeBSXIfExists(string s) {return ((s.at(0) == '\\') && (s.at(1) == 'x')) ? s.substr(2) : s;};
     void addWriteQueue(const string sqlWrite);
     void signalEmptyWriteQueue() {};
 
 public:
-    static DatabaseMap dbCache; // Local database based on a map attribute
-    static bool dbLoaded2Cache; // Indicates if we have already loaded the database into the mem cache for this process
+    static DatabaseMTCache dbMTCache;
+    static DatabaseProgramCache dbProgramCache;
 
     Database(Goldilocks &fr) : fr(fr) {};
     ~Database();
@@ -56,7 +56,6 @@ public:
     zkresult write(const string &_key, const vector<Goldilocks::Element> &value, const bool persistent);
     zkresult getProgram(const string &_key, vector<uint8_t> &value, DatabaseMap *dbReadLog);
     zkresult setProgram(const string &_key, const vector<uint8_t> &value, const bool persistent);
-    void loadDB2MemCache();
     void processWriteQueue();
     void setAutoCommit(const bool autoCommit);
     void commit();
@@ -65,6 +64,6 @@ public:
     void printTree(const string &root, string prefix = "");
 };
 
-void* asyncDatabaseWriteThread(void* arg);
+void loadDb2MemCache(const Config config);
 
 #endif

--- a/src/statedb/database_cache.cpp
+++ b/src/statedb/database_cache.cpp
@@ -1,0 +1,200 @@
+#include "database_cache.hpp"
+#include "utils.hpp"
+#include "scalar.hpp"
+
+// DatabaseCache class implementation
+
+// Add a record in the head of the cache. Returns true if the cache is full (or no cache), false otherwise
+bool DatabaseCache::addRecord(const string key, DatabaseCacheRecord* record) 
+{
+    if (cacheSize == 0) return true;
+
+    DatabaseCacheRecord* tmpRecord;
+    // If key already exists in the cache return. The findKey also sets the record in the head of the cache
+    if (findKey(key, tmpRecord)) return false;
+
+    bool full = false;
+
+    record->prev = NULL;
+    if (head == NULL) 
+    {
+        record->next = NULL;
+        last = record;
+    } 
+    else 
+    {
+        record->next = head;
+        head->prev = record;
+    }
+    head = record;
+
+    cacheMap[key] = record;
+
+    if (cacheSize == -1) return false; // no cache limit
+
+    cacheCurrentSize += record->size;
+    full = (cacheCurrentSize > cacheSize); 
+    // remove lats records from the cache to be under cacheSize
+    while (cacheCurrentSize > cacheSize) 
+    {
+        // Set new last record
+        DatabaseCacheRecord* tmp = last;
+        if (last->prev != NULL) last->prev->next = NULL;
+        last = last->prev;
+        // Free old last record
+        cacheMap.erase(tmp->key);
+        freeRecord(tmp);
+        // Update cache size
+        cacheCurrentSize -= tmp->size;      
+    }
+
+    return full;
+}
+
+bool DatabaseCache::findKey(const string key, DatabaseCacheRecord* &record) 
+{
+    unordered_map<string, DatabaseCacheRecord*>::iterator it = cacheMap.find(key);
+
+    if (it != cacheMap.end())
+    {
+        record = (DatabaseCacheRecord*)it->second;
+
+        // Move cache record to the top/head (if it's not the current head)
+        if (head != record) 
+        {
+            // Remove record from the current position
+            record->prev->next = record->next;
+
+            // If record is the last then set record->prev as the new last
+            if (last == record) last = record->prev;
+            else record->next->prev = record->prev;
+            
+            // Put record on top/head of the list
+            head->prev = record;
+            record->prev = NULL;
+            record->next = head;
+            head = record;
+        }
+        return true;
+    }
+    return false;
+}
+
+void DatabaseCache::print(bool printContent)
+{
+    cout << "Cache current size: " << cacheCurrentSize << endl;
+    cout << "Cache max size: " << cacheSize << endl;
+    cout << "Head: " << (head != NULL ? head->key : "NULL") << endl;
+    cout << "Last: " << (last != NULL ? last->key : "NULL") << endl;
+    
+    DatabaseCacheRecord* record = head;
+    uint64_t count = 0;
+    uint64_t size = 0;
+    while (record != NULL) 
+    {
+        if (printContent)
+        {
+            cout << "key:" << record->key << endl;
+        }
+        count++;
+        size += record->size;
+        record = record->next;
+    }
+    cout << "Cache count: " << count << endl;
+    cout << "Cache calculated size: " << size << endl;
+}
+
+DatabaseCache::~DatabaseCache()
+{
+    DatabaseCacheRecord* record = head;
+    DatabaseCacheRecord* tmp;
+    // Free cache records
+    while (record != NULL) 
+    {
+        tmp = record->next;
+        freeRecord(record);
+        record = tmp;
+    }
+}
+
+// DatabaseMTCache class implementation
+
+// Add a record in the head of the MT cache. Returns true if the cache is full (or no cache), false otherwise
+bool DatabaseMTCache::add(const string key, vector<Goldilocks::Element> value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if (cacheSize == 0) return true;
+
+    DatabaseCacheRecord* record = new(DatabaseCacheRecord);
+    vector<Goldilocks::Element>* pValue = new(vector<Goldilocks::Element>);
+    *pValue = value;
+    record->value = pValue;
+    record->key = key;
+    //TODO: Use hardcoded value for the mtValue size (8*Goldilocks::Element)?
+    record->size = sizeof(DatabaseCacheRecord)+record->key.size()+sizeof(Goldilocks::Element)*pValue->size();
+
+    return addRecord(key, record);
+}
+
+bool DatabaseMTCache::find(const string key, vector<Goldilocks::Element> &value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if (cacheSize == 0) return false;
+
+    DatabaseCacheRecord* record;
+    bool found = findKey(key, record);
+    if (found) 
+    {
+        value = *((vector<Goldilocks::Element>*) record->value);
+    }
+
+    return found;
+}
+
+void DatabaseMTCache::freeRecord(DatabaseCacheRecord* record)
+{
+    delete (vector<Goldilocks::Element>*)(record->value);
+    delete record;
+}
+
+// DatabaseProgramCache class implementation
+// Add a record in the head of the Program cache. Returns true if the cache is full (or no cache), false otherwise
+bool DatabaseProgramCache::add(const string key, vector<uint8_t> value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if (cacheSize == 0) return true;
+
+    DatabaseCacheRecord* record = new(DatabaseCacheRecord);
+    vector<uint8_t>* pValue = new(vector<uint8_t>);
+    *pValue = value;
+    record->value = pValue;
+    record->key = key;
+    record->size = sizeof(DatabaseCacheRecord)+record->key.size()+pValue->size();
+
+    return addRecord(key, record);
+}
+
+bool DatabaseProgramCache::find(const string key, vector<uint8_t> &value)
+{
+    lock_guard<recursive_mutex> guard(mlock);
+
+    if (cacheSize == 0) return false;
+
+    DatabaseCacheRecord* record;
+    bool found = findKey(key, record);
+    if (found) 
+    {
+        value = *((vector<uint8_t>*) record->value);
+    }
+
+    return found;
+}
+
+void DatabaseProgramCache::freeRecord(DatabaseCacheRecord* record)
+{
+    delete (vector<uint8_t>*)(record->value);
+    delete record;
+}

--- a/src/statedb/database_cache.cpp
+++ b/src/statedb/database_cache.cpp
@@ -131,8 +131,11 @@ bool DatabaseMTCache::add(const string key, vector<Goldilocks::Element> value)
     *pValue = value;
     record->value = pValue;
     record->key = key;
-    //TODO: Use hardcoded value for the mtValue size (8*Goldilocks::Element)?
-    record->size = sizeof(DatabaseCacheRecord)+record->key.size()+sizeof(Goldilocks::Element)*pValue->size();
+    record->size = 
+        sizeof(DatabaseCacheRecord)+
+        (record->key.capacity()+1)+
+        sizeof(vector<Goldilocks::Element>)+
+        sizeof(Goldilocks::Element)*pValue->capacity();
 
     return addRecord(key, record);
 }
@@ -172,7 +175,11 @@ bool DatabaseProgramCache::add(const string key, vector<uint8_t> value)
     *pValue = value;
     record->value = pValue;
     record->key = key;
-    record->size = sizeof(DatabaseCacheRecord)+record->key.size()+pValue->size();
+    record->size = 
+        sizeof(DatabaseCacheRecord)+
+        (record->key.capacity()+1)+
+        sizeof(vector<uint8_t>)+
+        pValue->capacity();
 
     return addRecord(key, record);
 }

--- a/src/statedb/database_cache.hpp
+++ b/src/statedb/database_cache.hpp
@@ -1,0 +1,58 @@
+#ifndef DATABASE_CACHE_HPP
+#define DATABASE_CACHE_HPP
+
+#include <vector>
+#include "goldilocks_base_field.hpp"
+#include <nlohmann/json.hpp>
+#include <mutex>
+
+using namespace std;
+using json = nlohmann::json;
+
+struct DatabaseCacheRecord {
+    string key; // TODO: use *char instead? it uses less memory than a string, but we need to convert
+    void* value;
+    DatabaseCacheRecord* next;
+    DatabaseCacheRecord* prev;
+    uint64_t size;
+};
+
+class DatabaseCache
+{
+protected:
+    recursive_mutex mlock;
+    int64_t cacheSize = 0;
+    int64_t cacheCurrentSize = 0;
+    unordered_map<string, DatabaseCacheRecord*> cacheMap;
+    DatabaseCacheRecord* head = NULL;
+    DatabaseCacheRecord* last = NULL;
+
+    DatabaseCache() : cacheCurrentSize(0), head(NULL), last(NULL) {};
+    ~DatabaseCache();
+    bool addRecord(const string key, DatabaseCacheRecord* record); // returns true if cache is full
+    bool findKey(const string key, DatabaseCacheRecord* &record);
+    virtual void freeRecord(DatabaseCacheRecord* record) {};
+
+public:
+    bool enabled() {return ((cacheSize == -1) || (cacheSize > 0));};
+    void setCacheSize(int64_t size) {cacheSize = size;}; // size is in bytes. 0 = no cache; -1 = cache no limit
+    void print(bool printContent);
+};
+
+class DatabaseMTCache : public DatabaseCache
+{
+public:  
+    bool add(const string key, vector<Goldilocks::Element> value); // returns true if cache is full
+    bool find(const string key, vector<Goldilocks::Element> &value);
+    void freeRecord(DatabaseCacheRecord* record);
+};
+
+class DatabaseProgramCache : public DatabaseCache
+{
+public:  
+    bool add(const string key, vector<uint8_t> value); // returns true if cache is full
+    bool find(const string key, vector<uint8_t> &value);
+    void freeRecord(DatabaseCacheRecord* record);
+};
+
+#endif

--- a/src/utils/scalar.cpp
+++ b/src/utils/scalar.cpp
@@ -60,6 +60,21 @@ void string2fe (Goldilocks &fr, const string &s, Goldilocks::Element &fe)
     fr.fromString(fe, Remove0xIfPresent(s), 16);
 }
 
+void string2fea(Goldilocks &fr, const string os, vector<Goldilocks::Element> &fea)
+{
+    Goldilocks::Element fe;
+    for (uint64_t i = 0; i < os.size(); i += 16)
+    {
+        if (i + 16 > os.size())
+        {
+            cerr << "Error: Database::string2fea() found incorrect DATA column size: " << os.size() << endl;
+            exitProcess();
+        }
+        string2fe(fr, os.substr(i, 16), fe);
+        fea.push_back(fe);
+    }
+}
+
 string fea2string (Goldilocks &fr, const Goldilocks::Element(&fea)[4])
 {
     mpz_class auxScalar;
@@ -338,6 +353,23 @@ string string2ba (const string &textString)
     string result;
     string2ba(textString, result);
     return result;
+}
+
+void string2ba(const string os, vector<uint8_t> &data)
+{
+    string s = Remove0xIfPresent(os);
+
+    if (s.size()%2 != 0)
+    {
+        s = "0" + s;
+    }
+
+    uint64_t dsize = s.size()/2;
+    const char *p = s.c_str();
+    for (uint64_t i=0; i<dsize; i++)
+    {
+        data.push_back(char2byte(p[2*i])*16 + char2byte(p[2*i + 1]));
+    }
 }
 
 void ba2string (string &s, const uint8_t *pData, uint64_t dataSize)
@@ -720,3 +752,4 @@ uint64_t swapBytes64 (uint64_t input)
             (((input) & 0x000000000000ff00ull) << 40) |
             (((input) & 0x00000000000000ffull) << 56));
 }
+

--- a/src/utils/scalar.hpp
+++ b/src/utils/scalar.hpp
@@ -240,6 +240,7 @@ void scalar2key (Goldilocks &fr, mpz_class &s, Goldilocks::Element (&key)[4]);
 
 /* Hexa string to/from field element (array) conversion */
 void string2fe  (Goldilocks &fr, const string &s, Goldilocks::Element &fe);
+void string2fea (Goldilocks &fr, const string os, vector<Goldilocks::Element> &fea);
 string fea2string (Goldilocks &fr, const Goldilocks::Element(&fea)[4]);
 string fea2string (Goldilocks &fr, const Goldilocks::Element &fea0, const Goldilocks::Element &fea1, const Goldilocks::Element &fea2, const Goldilocks::Element &fea3);
 
@@ -270,6 +271,8 @@ string  byte2string(uint8_t b);
 uint64_t string2ba (const string &s, uint8_t *pData, uint64_t &dataSize);
 void     string2ba (const string &textString, string &baString);
 string   string2ba (const string &textString);
+void     string2ba (const string os, vector<uint8_t> &data);
+
 void     ba2string (string &s, const uint8_t *pData, uint64_t dataSize);
 string   ba2string (const uint8_t *pData, uint64_t dataSize);
 void     ba2string (const string &baString, string &textString);


### PR DESCRIPTION
Limit db cache size. Added config parameters to define the cache size for the merkle-tree and program (SC)
Added config parameter to load the db to cache in a parallel thread (instead from the main thread)