### PR TITLE
Fail gracefully if Database::readTreeRemote fails. Create config.dbRe…

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -439,6 +439,10 @@ void Config::load(json &config)
     if (config.contains("dbGetTree") && config["dbGetTree"].is_boolean())
         dbGetTree = config["dbGetTree"];
 
+    dbReadOnly = false;
+    if (config.contains("dbReadOnly") && config["dbReadOnly"].is_boolean())
+        dbReadOnly = config["dbReadOnly"];
+
     if (config.contains("cleanerPollingPeriod") && config["cleanerPollingPeriod"].is_number())
         cleanerPollingPeriod = config["cleanerPollingPeriod"];
 
@@ -606,6 +610,7 @@ void Config::print(void)
     cout << "    dbMetrics=" << to_string(dbMetrics) << endl;
     cout << "    dbClearCache=" << to_string(dbClearCache) << endl;
     cout << "    dbGetTree=" << to_string(dbGetTree) << endl;
+    cout << "    dbReadOnly=" << to_string(dbReadOnly) << endl;
     cout << "    cleanerPollingPeriod=" << cleanerPollingPeriod << endl;
     cout << "    requestsPersistence=" << requestsPersistence << endl;
     cout << "    maxExecutorThreads=" << maxExecutorThreads << endl;

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -131,6 +131,7 @@ public:
     bool dbMetrics;
     bool dbClearCache;
     bool dbGetTree;
+    bool dbReadOnly;
     uint64_t cleanerPollingPeriod;
     uint64_t requestsPersistence;
     uint64_t maxExecutorThreads;

--- a/src/statedb/database.cpp
+++ b/src/statedb/database.cpp
@@ -305,7 +305,7 @@ void Database::initRemote(void)
     }
 
     // If configured to use the get tree function, we must install it in the database before using it
-    if (config.dbGetTree)
+    if (config.dbGetTree && !config.dbReadOnly)
     {
         writeGetTreeFunction();
     }
@@ -539,7 +539,7 @@ zkresult Database::readTreeRemote(const string &key, const vector<uint64_t> *key
     catch (const std::exception &e)
     {
         zklog.error("Database::readTreeRemote() exception: " + string(e.what()) + " connection=" + to_string((uint64_t)pDatabaseConnection));
-        exitProcess();
+        return ZKR_DB_ERROR;
     }
     
     // Dispose the read db conneciton


### PR DESCRIPTION
…adOnly to avoid calling writeGetTreeFunction for nothing.