### PR TITLE
Linear hash no batch

### DIFF
--- a/src/starkpil/merkleTree/merkleTreeGL.cpp
+++ b/src/starkpil/merkleTree/merkleTreeGL.cpp
@@ -36,10 +36,9 @@ void MerkleTreeGL::genMerkleProof(Goldilocks::Element *proof, uint64_t idx, uint
 
 void MerkleTreeGL::merkelize()
 {
-    uint64_t batch_size = std::max((uint64_t)8, (width + 3) / 4);
 #ifdef __AVX512__
-    PoseidonGoldilocks::merkletree_batch_avx512(nodes, source, width, height, batch_size);
+    PoseidonGoldilocks::merkletree_avx512(nodes, source, width, height);
 #else
-    PoseidonGoldilocks::merkletree_batch_avx(nodes, source, width, height, batch_size);
+    PoseidonGoldilocks::merkletree_avx(nodes, source, width, height);
 #endif
 }

--- a/tools/starkpil/bctree/build_const_tree.cpp
+++ b/tools/starkpil/bctree/build_const_tree.cpp
@@ -379,7 +379,7 @@ void buildConstTree(const string constFile, const string starkStructFile, const 
             numThreads = 1;
         }
         Goldilocks::parcpy(&constTree[header], constPolsArrayE, nPols * nExt, numThreads);
-        PoseidonGoldilocks::merkletree_batch(&constTree[numElementsCopy], constPolsArrayE, nPols, nExt, batchSize);
+        PoseidonGoldilocks::merkletree(&constTree[numElementsCopy], constPolsArrayE, nPols, nExt);
         TimerStopAndLog(MerkleTree_GL);
 
         cout << time() << " Generating files..." << endl;


### PR DESCRIPTION
Since there is no intention of moving to GPU in short period of time, removing batches when calculating linear hashes