### PR TITLE
Rick/srt_no_tonelli

### DIFF
--- a/src/main_sm/fork_5/main/eval_command.cpp
+++ b/src/main_sm/fork_5/main/eval_command.cpp
@@ -9,6 +9,10 @@
 
 namespace fork_5
 {
+    // As our field prime p, verifies p = 3 mod 4, for any r, sqrt(r) = r^((p+1)/4), check:
+    // https://www.rieselprime.de/ziki/Modular_square_root. FSQRT_EXP is (p+1)/4.
+    mpz_class FSQRTEXP("0x3fffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffff0c");
+    mpz_class FPRIME("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F");
 
 #ifdef DEBUG
 #define CHECK_EVAL_COMMAND_PARAMETERS
@@ -2253,13 +2257,20 @@ void eval_sqrtFpEc (Context &ctx, const RomCommand &cmd, CommandResult &cr)
     }
 #endif
 
-    RawFec::Element pfe = ctx.fec.negOne();
-    mpz_class p;
-    ctx.fec.toMpz(p.get_mpz_t(), pfe); // TODO: Avoid converting evry time, create a global value
-    p++;
+    // We use that p = 3 mod 4, so r = a^((p+1)/4) is a square root of a
+    // https://www.rieselprime.de/ziki/Modular_square_root
     mpz_class a = cr.scalar;
     cr.type = crt_scalar;
-    cr.scalar = sqrtTonelliShanks(a, p);
+    mpz_class result;
+    mpz_powm(result.get_mpz_t(), a.get_mpz_t(), FSQRTEXP.get_mpz_t(), FPRIME.get_mpz_t());
+    if ((result * result) % FPRIME != a)
+    {
+        cr.scalar = 0;
+    }
+    else
+    {
+        cr.scalar = result;
+    }
 }
 
 /********************/


### PR DESCRIPTION
To perform sqrt we take into account that the prime of the field used in secp256k1:

p = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE
FFFFFC2F

verifies:

 p = 3 mod 4

consequently:

 r = a^((p+1)/4) is a square root of a
  
details: https://www.rieselprime.de/ziki/Modular_square_rootsecp256k1