### PR TITLE
move config and mutex

### DIFF
--- a/src/hashdb/state_manager.hpp
+++ b/src/hashdb/state_manager.hpp
@@ -69,11 +69,10 @@ private:
     unordered_map<string, BatchState> state;
 #ifdef LOG_TIME_STATISTICS_STATE_MANAGER
     TimeMetricStorage timeMetricStorage;
-
 #endif
     Config config;
     pthread_mutex_t mutex; // Mutex to protect the multi write queues
-#endif
+
 public:
     StateManager ()
     {        

--- a/src/hashdb/state_manager.hpp
+++ b/src/hashdb/state_manager.hpp
@@ -69,6 +69,8 @@ private:
     unordered_map<string, BatchState> state;
 #ifdef LOG_TIME_STATISTICS_STATE_MANAGER
     TimeMetricStorage timeMetricStorage;
+
+#endif
     Config config;
     pthread_mutex_t mutex; // Mutex to protect the multi write queues
 #endif

--- a/src/hashdb64/state_manager_64.hpp
+++ b/src/hashdb64/state_manager_64.hpp
@@ -69,9 +69,10 @@ private:
     unordered_map<string, BatchState64> state;
 #ifdef LOG_TIME_STATISTICS_STATE_MANAGER
     TimeMetricStorage timeMetricStorage;
+
+#endif
     Config config;
     pthread_mutex_t mutex; // Mutex to protect the multi write queues
-#endif
 public:
     StateManager64 ()
     {        


### PR DESCRIPTION
if you disable these two options you will get compilation errors, I've moved where the config and mutex are defined:

```
//#define LOG_TIME_STATISTICS_MAIN_EXECUTOR
//#define LOG_TIME_STATISTICS_STATE_MANAGER
```