### PR TITLE
Added recursive_mutex in associative cache

### DIFF
--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -209,6 +209,11 @@ void DatabaseMTAssociativeCache::addKeyValue(Goldilocks::Element (&key)[4], cons
         values[cacheIndexValue + 9] = value[9];
         values[cacheIndexValue + 10] = value[10];
         values[cacheIndexValue + 11] = value[11];
+    }else{
+        values[cacheIndexValue + 8] = Goldilocks::zero();
+        values[cacheIndexValue + 9] = Goldilocks::zero();
+        values[cacheIndexValue + 10] = Goldilocks::zero();
+        values[cacheIndexValue + 11] = Goldilocks::zero();
     }
     //
     // Forced index insertion

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -46,6 +46,7 @@ DatabaseMTAssociativeCache::~DatabaseMTAssociativeCache()
 
 void DatabaseMTAssociativeCache::postConstruct(int nKeyBits_, int log2CacheSize_, string name_)
 {
+    lock_guard<recursive_mutex> guard(mlock);
     nKeyBits = nKeyBits_;
     if (nKeyBits_ > 32)
     {
@@ -102,7 +103,7 @@ void DatabaseMTAssociativeCache::postConstruct(int nKeyBits_, int log2CacheSize_
 
 void DatabaseMTAssociativeCache::addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update)
 {
-
+    lock_guard<recursive_mutex> guard(mlock);
     //
     //  Statistics
     //
@@ -280,6 +281,7 @@ void DatabaseMTAssociativeCache::forcedInsertion(uint32_t (&rawCacheIndexes)[10]
 
 bool DatabaseMTAssociativeCache::findKey(Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value)
 {
+    lock_guard<recursive_mutex> guard(mlock);
     attempts++; 
     for (int i = 0; i < 4; i++)
     {


### PR DESCRIPTION
* Added mutexes in associative cache to avoid race conditions
* Also when vectors of 8 values are added to the cache ensure in all cases that the remaining 4 positions of the cache cache slot are set to zero.