### PR TITLE
Fix Dockerfile on `develop`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,8 +70,7 @@ jobs:
        echo "Run, Build Application using script"
        git submodule init
        git submodule update
-       sudo apt install build-essential libbenchmark-dev libomp-dev libgmp-dev nlohmann-json3-dev postgresql libpqxx-dev libpqxx-doc nasm libsecp256k1-dev grpc-proto libsodium-dev libprotobuf-dev libssl-dev cmake libgrpc++-dev protobuf-compiler protobuf-compiler-grpc uuid-dev
-       make
+       sudo apt install build-essential libbenchmark-dev libomp-dev libgmp-dev nlohmann-json3-dev postgresql libpqxx-dev libpqxx-doc nasm libsecp256k1-dev grpc-proto libsodium-dev libprotobuf-dev libssl-dev cmake libgrpc++-dev protobuf-compiler protobuf-compiler-grpc uuid-dev make
 
     # - run: |
     #     echo "Run, Build Application using script"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 as build
 
 WORKDIR /usr/src/app
 
-RUN apt update && apt install -y build-essential libgmp-dev libbenchmark-dev nasm nlohmann-json3-dev libsecp256k1-dev libomp-dev libpqxx-dev git libssl-dev cmake libgrpc++-dev libprotobuf-dev grpc-proto libsodium-dev protobuf-compiler protobuf-compiler-grpc uuid-dev
+RUN apt update && apt install -y build-essential libbenchmark-dev libomp-dev libgmp-dev nlohmann-json3-dev postgresql libpqxx-dev libpqxx-doc nasm libsecp256k1-dev grpc-proto libsodium-dev libprotobuf-dev libssl-dev cmake libgrpc++-dev protobuf-compiler protobuf-compiler-grpc uuid-dev
 
 COPY ./src ./src
 COPY ./test ./test
@@ -14,7 +14,7 @@ FROM ubuntu:22.04
 
 WORKDIR /usr/src/app
 
-RUN apt update && apt install -y build-essential libgmp-dev nlohmann-json3-dev libsecp256k1-dev libomp-dev libpqxx-dev libssl-dev libgrpc++-dev libprotobuf-dev grpc-proto libsodium-dev protobuf-compiler protobuf-compiler-grpc uuid-dev
+RUN apt update && apt install -y build-essential libbenchmark-dev libomp-dev libgmp-dev nlohmann-json3-dev postgresql libpqxx-dev libpqxx-doc nasm libsecp256k1-dev grpc-proto libsodium-dev libprotobuf-dev libssl-dev cmake libgrpc++-dev protobuf-compiler protobuf-compiler-grpc uuid-dev
 
 COPY --from=build /usr/src/app/build/zkProver /usr/local/bin
 

--- a/Dockerfile-GHA
+++ b/Dockerfile-GHA
@@ -1,10 +1,7 @@
 FROM ubuntu:22.04 as build
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libgmp-dev \
-    libbenchmark-dev nasm nlohmann-json3-dev libsecp256k1-dev libomp-dev \
-    libpqxx-dev git libssl-dev cmake libgrpc++-dev libprotobuf-dev grpc-proto \
-    libsodium-dev protobuf-compiler protobuf-compiler-grpc uuid-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libbenchmark-dev libomp-dev libgmp-dev nlohmann-json3-dev postgresql libpqxx-dev libpqxx-doc nasm libsecp256k1-dev grpc-proto libsodium-dev libprotobuf-dev libssl-dev cmake libgrpc++-dev protobuf-compiler protobuf-compiler-grpc uuid-dev && \
     rm -fr /var/cache/apt/*
 
 WORKDIR /usr/src/app
@@ -28,9 +25,7 @@ COPY ./src/main_sm/fork_4/scripts/rom.json ./src/main_sm/fork_4/scripts/rom.json
 COPY ./src/main_sm/fork_5/scripts/rom.json ./src/main_sm/fork_5/scripts/rom.json
 
 RUN DEBIAN_FRONTEND=noninteractive apt update && \
-    DEBIAN_FRONTEND=noninteractive apt install -y libgmp-dev \
-    nlohmann-json3-dev libsecp256k1-dev libomp-dev libpqxx-dev libssl-dev \
-    libgrpc++-dev libprotobuf-dev grpc-proto libsodium-dev && \
+    DEBIAN_FRONTEND=noninteractive apt install -y build-essential libbenchmark-dev libomp-dev libgmp-dev nlohmann-json3-dev postgresql libpqxx-dev libpqxx-doc nasm libsecp256k1-dev grpc-proto libsodium-dev libprotobuf-dev libssl-dev cmake libgrpc++-dev protobuf-compiler protobuf-compiler-grpc uuid-dev && \
     rm -fr /var/cache/apt/*
 
 COPY --from=build /usr/src/app/build/zkProver /usr/local/bin/zkProver

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 CXX := g++
 AS := nasm
 CXXFLAGS := -std=c++17 -Wall -pthread -flarge-source-files -Wno-unused-label -rdynamic -mavx2 $(GRPCPP_FLAGS) #-Wfatal-errors
-LDFLAGS := -lprotobuf -lsodium -lgpr -lpthread -lpqxx -lpq -lgmp -lstdc++ -lgmpxx -lsecp256k1 -lcrypto -luuid $(GRPCPP_LIBS) $(ABSL_LIBS)
+LDFLAGS := -lprotobuf -lsodium -lgpr -lpthread -lpqxx -lpq -lgmp -lomp -lstdc++ -lgmpxx -lsecp256k1 -lcrypto -luuid $(GRPCPP_LIBS) $(ABSL_LIBS)
 CFLAGS := -fopenmp
 ASFLAGS := -felf64
 


### PR DESCRIPTION
Re-add missing `-lomp` LDFLAG, which for some reason isn't needed on my Ubuntu 22.04 virtual image, but of course, is needed on others. Also update package dependency calls from package manager.