### PR TITLE
Pass -fopenmp to linker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update && apt install -y build-essential libgmp-dev libbenchmark-dev nas
 COPY ./src ./src
 COPY ./test ./test
 COPY ./tools ./tools
+COPY ./config ./config
 COPY Makefile .
 RUN make -j
 
@@ -17,6 +18,14 @@ WORKDIR /usr/src/app
 RUN apt update && apt install -y build-essential libgmp-dev nlohmann-json3-dev libsecp256k1-dev libomp-dev libpqxx-dev libssl-dev libgrpc++-dev libprotobuf-dev grpc-proto libsodium-dev protobuf-compiler protobuf-compiler-grpc uuid-dev
 
 COPY --from=build /usr/src/app/build/zkProver /usr/local/bin
+
+COPY ./testvectors ./testvectors
+COPY ./config ./config
+COPY ./src/main_sm/fork_1/scripts/rom.json ./src/main_sm/fork_1/scripts/rom.json
+COPY ./src/main_sm/fork_2/scripts/rom.json ./src/main_sm/fork_2/scripts/rom.json
+COPY ./src/main_sm/fork_3/scripts/rom.json ./src/main_sm/fork_3/scripts/rom.json
+COPY ./src/main_sm/fork_4/scripts/rom.json ./src/main_sm/fork_4/scripts/rom.json
+COPY ./src/main_sm/fork_5/scripts/rom.json ./src/main_sm/fork_5/scripts/rom.json
 
 ENTRYPOINT [ "zkProver" ]
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 CXX := g++
 AS := nasm
 CXXFLAGS := -std=c++17 -Wall -pthread -flarge-source-files -Wno-unused-label -rdynamic -mavx2 $(GRPCPP_FLAGS) #-Wfatal-errors
-LDFLAGS := -lprotobuf -lsodium -lgpr -lpthread -lpqxx -lpq -lgmp -lstdc++ -lgmpxx -lsecp256k1 -lcrypto -luuid $(GRPCPP_LIBS) $(ABSL_LIBS)
+LDFLAGS := -lprotobuf -lsodium -lgpr -lpthread -lpqxx -lpq -lgmp -lstdc++ -lgmpxx -lsecp256k1 -lcrypto -luuid -fopenmp $(GRPCPP_LIBS) $(ABSL_LIBS)
 CFLAGS := -fopenmp
 ASFLAGS := -felf64
 


### PR DESCRIPTION
Fixes issues with building from Docker, apparently.