### PR TITLE
rick/test ecrecover

### DIFF
--- a/test/sm/ecrecover/ecrecover_test.cpp
+++ b/test/sm/ecrecover/ecrecover_test.cpp
@@ -19,7 +19,7 @@ struct ECRecoverTestVector
     ECRecoverResult result;
     string address;
 };
-#define NTESTS 46
+#define NTESTS 47
 #define REPETITIONS 1
 #define BENCHMARK_MODE 0 // 0: test mode, 1: benchmark mode
 
@@ -306,7 +306,13 @@ ECRecoverTestVector ecrecoverTestVectors[] = {
      "9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608",
      "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
      "1c", false, ECR_S_IS_TOO_BIG,
-     "0000000000000000000000000000000000000000"}};
+     "0000000000000000000000000000000000000000"},
+     // 46 tests jacobian comparison
+     {"362C64CAC78B18F0528AA9D9270116CB12F14B1C3920465855FA6EE0FC35BEB8",
+     "C6047F9441ED7D6D3045406E95C07CD85C778E4B8CEF3CA7ABAC09B95C709EE5",
+     "4296A072F8ADB4A62ABAE833A1B15350196EB00AE7C5260098628C6C68D95392",
+     "1b", false, ECR_NO_ERROR,
+     "f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"}};
 
 void ECRecoverTest(void)
 {


### PR DESCRIPTION
Added test case in ecrecover_test.cpp which accounts for a found bug on the evaluation of ECRecover with Jacobian coordinates. The bug was fixed in commit: 715846814f5b9489ee11fa4e0aa6a6012a9c397a