### PR TITLE
testing/fixing associative caches

### DIFF
--- a/src/hashdb64/database_kv_associative_cache.cpp
+++ b/src/hashdb64/database_kv_associative_cache.cpp
@@ -99,7 +99,7 @@ void DatabaseKVAssociativeCache::addKeyValueVersion(const uint64_t version, cons
     bool present = false;
     bool presentSameVersion = false;
     uint32_t cacheIndex;
-    uint32_t tableIndexEmpty=0;
+    uint32_t tableIndexUse=0;
     uint32_t cacheIndexPrev;
 
     //
@@ -123,12 +123,13 @@ void DatabaseKVAssociativeCache::addKeyValueVersion(const uint64_t version, cons
                         presentSameVersion = true;
                         if(update == false) return;
                     }
+                    tableIndexUse = tableIndex;
                     cacheIndexPrev = cacheIndex;
                     break;
             }
         }else if (emptySlot == false){
             emptySlot = true;
-            tableIndexEmpty = tableIndex;
+            tableIndexUse = tableIndex;
         }
     }
 
@@ -136,8 +137,8 @@ void DatabaseKVAssociativeCache::addKeyValueVersion(const uint64_t version, cons
     // Evaluate cacheIndexKey and 
     //
     if(!presentSameVersion){
-        if(emptySlot == true){
-            indexes[tableIndexEmpty] = currentCacheIndex;
+        if(emptySlot == true || present){
+            indexes[tableIndexUse] = currentCacheIndex;
         }
         cacheIndex = (uint32_t)(currentCacheIndex & cacheMask);
         currentCacheIndex = (currentCacheIndex == UINT32_MAX) ? 0 : (currentCacheIndex + 1);
@@ -158,6 +159,8 @@ void DatabaseKVAssociativeCache::addKeyValueVersion(const uint64_t version, cons
     versions[cacheIndexVersions] = version;
     if(present & !presentSameVersion){
         versions[cacheIndexVersions+1] = cacheIndexPrev;
+    }else{
+        versions[cacheIndexVersions+1] = 0;
     }
     //
     // Forced index insertion

--- a/test/hashdb/database_associative_cache_test.cpp
+++ b/test/hashdb/database_associative_cache_test.cpp
@@ -2,53 +2,121 @@
 #include "hashdb/database.hpp"
 #include "timer.hpp"
 #include "scalar.hpp"
+#include "database_versions_associtive_cache.hpp"
+#include "database_kv_associative_cache.hpp"
 
 #define NUMBER_OF_DB_CACHE_ADDS 1000
 
 uint64_t DatabaseAssociativeCacheTest (void)
 {
     TimerStart(DATABASE_ASSOCIATIVE_CACHE_TEST);
-
     uint64_t numberOfFailed = 0;
-    Database::dbMTACache.postConstruct(20,17,"MTACache");
-    Goldilocks::Element key[4];
-
     Goldilocks fr;
-    mpz_class keyScalar;
+    bool update = false;
 
+    //
+    // Test DatabaseMTAssociativeCache
+    //
+    DatabaseMTAssociativeCache dbMTACache;
+    dbMTACache.postConstruct(20,17,"MTACache");
+    
+    Goldilocks::Element key[4];
+    mpz_class keyScalar;
     string keyString;
     vector<Goldilocks::Element> value;
     bool bResult;
+
     for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_ADDS; i++)
     {
         keyScalar = i;
-        keyString = PrependZeros(keyScalar.get_str(16), 64);
         value.clear();
         for (uint64_t j=0; j<12; j++)
         {
-            value.push_back(fr.fromU64(j));
+            value.push_back(fr.fromU64(12*i+j));
         }
-        bool update = false;
         scalar2fea(fr, keyScalar, key);
-        Database::dbMTACache.addKeyValue(key, value,update);
+        dbMTACache.addKeyValue(key, value,update);
     }
-
-    //Database::dbMTCache.print(true);
 
     for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_ADDS; i++)
     {
         keyScalar = i;
         keyString = PrependZeros(keyScalar.get_str(16), 64);
         scalar2fea(fr, keyScalar, key);
-        bResult = Database::dbMTACache.findKey(key, value);
+        bResult = dbMTACache.findKey(key, value);
 
-        if (!bResult)
+        if (!bResult || value.size() != 12 || value[0].fe != 12*i+0 || value[11].fe != 12*i+11)
         {
-            zklog.error("DatabaseCacheTest() failed calling Database::dbMTCache.find() of key=" + keyString);
+            zklog.error("DatabaseAssociativeCacheTest() failed calling DatabaseMTAssociativeCache.find() of key=" + keyString);
             numberOfFailed++;
         }
     }
-    Database::dbMTCache.clear();
+
+    //
+    // Test DatabaseVersionsAssociativeCache
+    //
+    DatabaseVersionsAssociativeCache dbVersionACache;
+    dbVersionACache.postConstruct(20,17,"VersionsACache");
+    Goldilocks::Element root[4];
+
+    mpz_class rootScalar;
+    string rootString;
+    uint64_t version = 1;
+
+    for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_ADDS; i++)
+    {
+        rootScalar = i;
+        scalar2fea(fr, rootScalar, root);
+        dbVersionACache.addKeyVersion(root, version);
+        version+=1;
+    }
+    for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_ADDS; i++)
+    {
+        rootScalar = i;
+        rootString = PrependZeros(rootScalar.get_str(16), 64);
+        scalar2fea(fr, rootScalar, root);
+        bResult = dbVersionACache.findKey(root, version);
+        
+        if (!bResult || version != i+1)
+        {
+            zklog.error("DatabaseAssociativeCacheTest() failed calling DatabaseVersionsAssociativeCache.find() of root=" + rootString + " version=" + to_string(version));
+            numberOfFailed++;
+        }
+    }
+    //
+    // Test DatabaseKVAssociativeCache
+    //
+    DatabaseKVAssociativeCache dbKVACache;
+    dbKVACache.postConstruct(20,18,"dbKVACache");
+    mpz_class valueScalar;
+
+    for(version=0; version<=10; version+=2){
+        for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_ADDS; i++){
+            keyScalar = i;
+            scalar2fea(fr, keyScalar, key);
+            valueScalar = (version/2)*NUMBER_OF_DB_CACHE_ADDS + i;
+            dbKVACache.addKeyValueVersion(version, key, valueScalar,update);
+        }
+    }
+    for(version=0; version<=10; version++){
+        for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_ADDS; i++){
+            keyScalar = i;
+            scalar2fea(fr, keyScalar, key);
+            bResult = dbKVACache.findKey(version,key, valueScalar);
+
+            if (!bResult || valueScalar != (version/2)*NUMBER_OF_DB_CACHE_ADDS + i)
+            {
+                zklog.error("DatabaseAssociativeCacheTest() failed calling DatabaseKVAssociativeCache.find() of key=" + keyString + " version=" + to_string(version) + " value=" + valueScalar.get_str(16));
+                numberOfFailed++;
+            }
+        }
+    }
+
+    if(numberOfFailed != 0)
+    {
+        zklog.error("DatabaseAssociativeCacheTest() failed with " + to_string(numberOfFailed) + " errors"); 
+        exitProcess();   
+    }
     TimerStopAndLog(DATABASE_ASSOCIATIVE_CACHE_TEST);
     return numberOfFailed;
 }


### PR DESCRIPTION
Added tests and fixed bugs for the associative caches. In particular, added test for the DatabaseVersionsAssociativeCache and DatabaseKVAssociativeCache. The bug found was in the latter. 