### PR TITLE
PageManager: flush free pages

### DIFF
--- a/src/hashdb64/page/header_page.cpp
+++ b/src/hashdb64/page/header_page.cpp
@@ -102,22 +102,53 @@ void HeaderPage::SetLastVersion (uint64_t &headerPageNumber, const uint64_t last
     page->lastVersion = lastVersion;
 }
 
-zkresult HeaderPage::GetFreePages (const uint64_t headerPageNumber, vector<uint64_t> (&containerPages), vector<uint64_t> (&containedPages))
+zkresult HeaderPage::GetFreePagesContainer (const uint64_t headerPageNumber, vector<uint64_t> (&containerPages))
 {
     // Get header page
     HeaderStruct * page = (HeaderStruct *)pageManager.getPageAddress(headerPageNumber);
 
     // Call the specific method
-    return PageListPage::GetPages(page->freePages, containerPages, containedPages);
+    return PageListPage::GetContainerPages (page->freePages, containerPages);
 }
 
-zkresult HeaderPage::CreateFreePages (uint64_t &headerPageNumber, vector<uint64_t> (&freePages), vector<uint64_t> (&containerPages), vector<uint64_t> (&containedPages))
+zkresult HeaderPage::GetFreePages (const uint64_t headerPageNumber, vector<uint64_t> (&freePages))
 {
     // Get header page
     HeaderStruct * page = (HeaderStruct *)pageManager.getPageAddress(headerPageNumber);
 
     // Call the specific method
-    return PageListPage::CreatePages(page->freePages, freePages, containerPages, containedPages);
+    freePages.clear();
+    return PageListPage::GetPages(page->freePages, freePages);
+}
+
+zkresult HeaderPage::CreateFreePages (uint64_t &headerPageNumber, vector<uint64_t> (&freePages), vector<uint64_t> (&containerPages))
+{
+
+    // Get an editable page
+    headerPageNumber = pageManager.editPage(headerPageNumber);
+
+    // Get header page
+    HeaderStruct * page = (HeaderStruct *)pageManager.getPageAddress(headerPageNumber);
+
+    // Call the specific method    
+    return PageListPage::CreatePages(page->freePages, freePages, containerPages);
+
+    return ZKR_SUCCESS;
+
+}
+
+zkresult HeaderPage::setFirstUnusedPage (uint64_t &headerPageNumber, const uint64_t firstUnusedPage)
+{
+    // Get an editable page
+    headerPageNumber = pageManager.editPage(headerPageNumber);
+
+    // Get header page
+    HeaderStruct * page = (HeaderStruct *)pageManager.getPageAddress(headerPageNumber);
+
+    // Call the specific method
+    page->firstUnusedPage = firstUnusedPage;
+
+    return ZKR_SUCCESS;
 }
 
 zkresult HeaderPage::ReadRootVersion (const uint64_t headerPageNumber, const string &root, uint64_t &version)

--- a/src/hashdb64/page/header_page.hpp
+++ b/src/hashdb64/page/header_page.hpp
@@ -30,6 +30,7 @@ struct HeaderStruct
 
     // Free pages list
     uint64_t freePages;
+    uint64_t firstUnusedPage;
 };
 
 class HeaderPage
@@ -41,8 +42,10 @@ public:
     static void     SetLastVersion (      uint64_t &headerPageNumber, const uint64_t lastVersion);
 
     // Free pages list methods
-    static zkresult GetFreePages    (const uint64_t  headerPageNumber,                                vector<uint64_t> (&containerPages), vector<uint64_t> (&containedPages));
-    static zkresult CreateFreePages (      uint64_t &headerPageNumber, vector<uint64_t> (&freePages), vector<uint64_t> (&containerPages), vector<uint64_t> (&containedPages));
+    static zkresult GetFreePagesContainer (const uint64_t  headerPageNumber, vector<uint64_t> (&containerPages));
+    static zkresult GetFreePages          (const uint64_t  headerPageNumber, vector<uint64_t> (&freePages));
+    static zkresult CreateFreePages       (      uint64_t &headerPageNumber, vector<uint64_t> (&freePages), vector<uint64_t> (&containerPages));
+    static zkresult setFirstUnusedPage    (      uint64_t &headerPageNumber, const uint64_t firstUnusedPage);
 
     // Root version methods
     static zkresult ReadRootVersion  (const uint64_t  headerPageNumber, const string &root,       uint64_t &version);

--- a/src/hashdb64/page/page_list_page.hpp
+++ b/src/hashdb64/page/page_list_page.hpp
@@ -40,13 +40,15 @@ public:
 
     static const uint64_t minOffset= 16; // This means that the page is completely empty
     static const uint64_t maxOffset = 4096; // This means that the page is completely full
+    static const uint64_t entrySize = 8; 
 
     static zkresult InitEmptyPage (const uint64_t  pageNumber);
     static zkresult InsertPage    (      uint64_t &pageNumber, const uint64_t pageNumberToInsert);
     static zkresult ExtractPage   (      uint64_t &pageNumber,       uint64_t &extractedPageNumber);
 
-    static zkresult GetPages      (const uint64_t  pageNumber,                                vector<uint64_t> (&containerPages), vector<uint64_t> (&containedPages));
-    static zkresult CreatePages   (      uint64_t &pageNumber, vector<uint64_t> (&freePages), vector<uint64_t> (&containerPages), vector<uint64_t> (&containedPages));
+    static zkresult GetPages          (const uint64_t  pageNumber, vector<uint64_t> (&freePages));
+    static zkresult CreatePages       (      uint64_t &pageNumber, vector<uint64_t> (&freePages), vector<uint64_t> (&containerPages));
+    static zkresult GetContainerPages (const uint64_t  pageNumber,                                vector<uint64_t> (&containerPages));
 
     static void Print (const uint64_t pageNumber, bool details, const string &prefix);
 };

--- a/src/hashdb64/page/page_manager.cpp
+++ b/src/hashdb64/page/page_manager.cpp
@@ -149,6 +149,7 @@ uint64_t PageManager::getFreePage(void)
         --numFreePages;
     }else{
         pageNumber = firstUnusedPage;
+        memset(getPageAddress(pageNumber), 0, 4096);
         firstUnusedPage++;
 #if MULTIPLE_WRITES
         shared_lock<shared_mutex> guard(pagesLock);

--- a/src/hashdb64/page/page_manager.cpp
+++ b/src/hashdb64/page/page_manager.cpp
@@ -11,6 +11,8 @@
 #include <unistd.h>
 #include <cerrno>
 #include <omp.h>
+#include "header_page.hpp"
+#include "page_list_page.hpp"
 
 PageManager pageManager;
 PageManager::PageManager()
@@ -41,11 +43,9 @@ PageManager::PageManager(const string fileName_, const uint64_t fileSize_, const
     nFiles = nFiles_;
     folderName = folderName_;
     pagesPerFile = fileSize >> 12;
-    numFreePages = 0;
-    freePages.resize(16384);
+    
 
     mappedFile = true;
-    struct stat file_stat;
     int fd;
     nPages = 0;
     uint64_t pagesPerFile = fileSize >> 12;
@@ -79,6 +79,15 @@ PageManager::PageManager(const string fileName_, const uint64_t fileSize_, const
     }
     zkassertpermanent(nPages > 2);
     firstUnusedPage = 2;
+
+    //Free pages
+    /*vector<uint64_t> freePagesDB;
+    HeaderPage::GetFreePages(0, freePagesDB); 
+    numFreePages = freePagesDB.size();
+    freePages.resize((numFreePages)*2+1);
+    memccpy(freePages.data(), freePagesDB.data(), 0, numFreePages*sizeof(uint64_t));*/
+    numFreePages = 0;
+    freePages.resize(16384);
 }
 PageManager::~PageManager(void)
 {
@@ -137,6 +146,7 @@ zkresult PageManager::addFile(){
 #if USE_FILE_IO
         fileDescriptors.push_back(fd);
 #endif
+    return zkresult::ZKR_SUCCESS;
 }
 uint64_t PageManager::getFreePage(void)
 {
@@ -194,15 +204,56 @@ uint64_t PageManager::editPage(const uint64_t pageNumber)
     }
     return pageNumber_;
 }
+
 void PageManager::flushPages(){
-    
-    if(!mappedFile){
-        unique_lock<shared_mutex> guard2(headerLock);
-        memcpy(getPageAddress(0), getPageAddress(1), 4096); // copy tmp header to header
-    }else{
+
 #if MULTIPLE_WRITES
+        lock_guard<mutex> guard(freePagesLock);
         shared_lock<shared_mutex> guard(pagesLock);
+        std::lock_guard<std::mutex> lock(editedPagesLock);
 #endif
+
+    //1// get list of previous used pages as freePages container
+    uint64_t headerPageNum = 0;
+    vector<uint64_t> prevFreePagesContainer;
+    HeaderPage::GetFreePagesContainer(headerPageNum, prevFreePagesContainer);
+
+    //2// get list of edited pages
+    vector<uint64_t> copiedPages;
+    for(unordered_map<uint64_t, uint64_t>::const_iterator it = editedPages.begin(); it != editedPages.end(); it++){
+        if(it->first != it->second && it->first >= 2){
+            copiedPages.emplace_back(it->first);
+        }
+    }
+
+    //3// generate new list of freePages
+    uint64_t nPrevFreePagesContainer = prevFreePagesContainer.size();
+    uint64_t nEditedPages = copiedPages.size();
+    uint64_t entriesPerPage = (PageListPage::maxOffset - PageListPage::minOffset) / PageListPage::entrySize; 
+    uint64_t nNewFreePages = numFreePages + nEditedPages + nPrevFreePagesContainer;
+    uint64_t nNewContainerPages = (nNewFreePages + entriesPerPage) / (entriesPerPage +1);
+    if(nNewContainerPages > numFreePages){
+        uint64_t nNewFreePages_ = nNewFreePages - numFreePages*(entriesPerPage +1);
+        uint64_t nAddedContanerPages = (nNewFreePages_ + entriesPerPage - 1) / entriesPerPage;
+        nNewContainerPages = numFreePages + nAddedContanerPages;
+    }
+    if(nNewContainerPages == 0) nNewContainerPages = 1; //at least one container page that will be empty
+
+    vector<uint64_t> newContainerPages(nNewContainerPages);
+    for(uint64_t i=0; i< nNewContainerPages; ++i){
+        newContainerPages[i]=getFreePage();
+    }
+
+    vector<uint64_t> newFreePages(numFreePages+nEditedPages+nPrevFreePagesContainer);
+    memcpy(newFreePages.data(), freePages.data(), numFreePages*sizeof(uint64_t));
+    memcpy(newFreePages.data()+numFreePages, prevFreePagesContainer.data(), nPrevFreePagesContainer*sizeof(uint64_t));
+    memcpy(newFreePages.data()+numFreePages+nPrevFreePagesContainer, copiedPages.data(), nEditedPages*sizeof(uint64_t));
+
+    HeaderPage::CreateFreePages(headerPageNum, newFreePages, newContainerPages);
+    HeaderPage::setFirstUnusedPage(headerPageNum, firstUnusedPage);
+
+    //4// sync all pages
+    if(mappedFile){
         #pragma omp parallel for schedule(static,1) num_threads(omp_get_num_threads()/2)
         for(uint64_t k=0; k< pages.size(); ++k){
             if(k==0){
@@ -211,22 +262,33 @@ void PageManager::flushPages(){
                 msync(pages[k], fileSize, MS_SYNC);
             }
         }
-        off_t offset = 0;
-        if(lseek(file0Descriptor, offset, SEEK_SET) == -1) {
-            zklog.error("Failed to seek file: " + (string)strerror(errno));
-            exitProcess();
-        }
-        unique_lock<shared_mutex> guard2(headerLock);
-        ssize_t write_size =write(file0Descriptor, getPageAddress(1), 4096); //how transactional is this?
-        zkassertpermanent(write_size == 4096);
     }
-#if MULTIPLE_WRITES
-    std::lock_guard<std::mutex> lock(editedPagesLock);
-#endif
-    for(unordered_map<uint64_t, uint64_t>::const_iterator it = editedPages.begin(); it != editedPages.end(); it++){
-        if(it->first != it->second && it->first >= 2){
-            releasePage(it->first);
+
+    //5// write header
+    {
+        unique_lock<shared_mutex> guard_header(headerLock);
+        if(mappedFile){
+            off_t offset = 0;
+            if(lseek(file0Descriptor, offset, SEEK_SET) == -1) {
+                zklog.error("Failed to seek file.");
+                exitProcess();
+            }
+            ssize_t write_size =write(file0Descriptor, getPageAddress(1), 4096); //how transactional is this?
+            zkassertpermanent(write_size == 4096);
+        }else{
+            memcpy(getPageAddress(0), getPageAddress(1), 4096);
         }
     }
+
+    //6// Release freePagesContainers 
+    for(vector<uint64_t>::const_iterator it = prevFreePagesContainer.begin(); it != prevFreePagesContainer.end(); it++){
+        releasePage(*it);
+    }
+
+    //7// Release edited pages
+    for(vector<uint64_t>::const_iterator it = copiedPages.begin(); it != copiedPages.end(); it++){
+        releasePage(*it);
+    }     
     editedPages.clear();
+
 }

--- a/test/hashdb/page_manager_test.cpp
+++ b/test/hashdb/page_manager_test.cpp
@@ -33,7 +33,6 @@ uint64_t PageManagerPerformanceTest(void){
     uint64_t numPositions = 20000;
     uint64_t numReps = 100;
     uint64_t printFreq = 10;
-    char singlePage[4096];
 
     // Create the state manager
     double start = omp_get_wtime();
@@ -73,9 +72,10 @@ uint64_t PageManagerPerformanceTest(void){
         }
 
         //Change first value of each page
-        uint64_t sum=0;
         start = omp_get_wtime();
 #if TEST_FILE_IO
+        char singlePage[4096];
+        uint64_t sum=0;
         //#pragma omp parallel for num_threads(64)
         for (uint64_t i = 0; i < numPositions; ++i) {
             pageManagerFile.getPageAddressFile(position[i], singlePage);


### PR DESCRIPTION
Implemented the process to flush the free pages within the flushPages() method of the PageManager. Each time the flushPages method is called the list of freePages is backed up into the persisten memory.