### PR TITLE
fix last opcode gas

### DIFF
--- a/src/main_sm/fork_1/main/full_tracer.cpp
+++ b/src/main_sm/fork_1/main/full_tracer.cpp
@@ -1131,12 +1131,34 @@ void FullTracer::onOpcode(Context &ctx, const RomCommand &cmd)
 
             prevTraceCall->gas_cost = prevTraceCall->gas - gasCTX;
         }
+        else if (prevTraceCall->depth != singleInfo.depth)
+        {
+            // Means opcode failed with error (ex: oog, invalidStaticTx...)
+            if (!prevTraceCall->error.empty())
+            {
+                prevTraceCall->gas_cost = prevTraceCall->gas;
+            }
+        }
         else
         {
             prevTraceCall->gas_cost = gasCost;
         }
 
         // cout << "info[info.size() - 1].gas_cost=" << info[info.size() - 1].gas_cost << endl;
+
+        // If gas cost is negative means gas has been added from a deeper context, it should be recalculated
+        if (prevTraceCall->gas_cost < 0)
+        {
+            if (full_trace.size() > 2)
+            {
+                prevTraceCall->gas_cost = full_trace[full_trace.size() - 2].gas - prevTraceCall->gas;
+            }
+            else
+            {
+                zklog.error("FullTracer::onOpcode() found full_trace.size=" + to_string(full_trace.size()) + " too low");
+                exitProcess();
+            }
+        }
 
         // Set gas refund for sstore opcode
         getVarFromCtx(ctx, false, ctx.rom.gasRefundOffset, auxScalar);

--- a/src/main_sm/fork_1/main/full_tracer.cpp
+++ b/src/main_sm/fork_1/main/full_tracer.cpp
@@ -726,7 +726,7 @@ void FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);

--- a/src/main_sm/fork_2/main/full_tracer.cpp
+++ b/src/main_sm/fork_2/main/full_tracer.cpp
@@ -730,7 +730,7 @@ void FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);

--- a/src/main_sm/fork_2/main/full_tracer.cpp
+++ b/src/main_sm/fork_2/main/full_tracer.cpp
@@ -1135,12 +1135,34 @@ void FullTracer::onOpcode(Context &ctx, const RomCommand &cmd)
 
             prevTraceCall->gas_cost = prevTraceCall->gas - gasCTX;
         }
+        else if (prevTraceCall->depth != singleInfo.depth)
+        {
+            // Means opcode failed with error (ex: oog, invalidStaticTx...)
+            if (!prevTraceCall->error.empty())
+            {
+                prevTraceCall->gas_cost = prevTraceCall->gas;
+            }
+        }
         else
         {
             prevTraceCall->gas_cost = gasCost;
         }
 
         // cout << "info[info.size() - 1].gas_cost=" << info[info.size() - 1].gas_cost << endl;
+
+        // If gas cost is negative means gas has been added from a deeper context, it should be recalculated
+        if (prevTraceCall->gas_cost < 0)
+        {
+            if (full_trace.size() > 2)
+            {
+                prevTraceCall->gas_cost = full_trace[full_trace.size() - 2].gas - prevTraceCall->gas;
+            }
+            else
+            {
+                zklog.error("FullTracer::onOpcode() found full_trace.size=" + to_string(full_trace.size()) + " too low");
+                exitProcess();
+            }
+        }
 
         // Set gas refund for sstore opcode
         getVarFromCtx(ctx, false, ctx.rom.gasRefundOffset, auxScalar);

--- a/src/main_sm/fork_3/main/full_tracer.cpp
+++ b/src/main_sm/fork_3/main/full_tracer.cpp
@@ -730,7 +730,7 @@ void FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);

--- a/src/main_sm/fork_3/main/full_tracer.cpp
+++ b/src/main_sm/fork_3/main/full_tracer.cpp
@@ -1135,12 +1135,34 @@ void FullTracer::onOpcode(Context &ctx, const RomCommand &cmd)
 
             prevTraceCall->gas_cost = prevTraceCall->gas - gasCTX;
         }
+        else if (prevTraceCall->depth != singleInfo.depth)
+        {
+            // Means opcode failed with error (ex: oog, invalidStaticTx...)
+            if (!prevTraceCall->error.empty())
+            {
+                prevTraceCall->gas_cost = prevTraceCall->gas;
+            }
+        }
         else
         {
             prevTraceCall->gas_cost = gasCost;
         }
 
         // cout << "info[info.size() - 1].gas_cost=" << info[info.size() - 1].gas_cost << endl;
+
+        // If gas cost is negative means gas has been added from a deeper context, it should be recalculated
+        if (prevTraceCall->gas_cost < 0)
+        {
+            if (full_trace.size() > 2)
+            {
+                prevTraceCall->gas_cost = full_trace[full_trace.size() - 2].gas - prevTraceCall->gas;
+            }
+            else
+            {
+                zklog.error("FullTracer::onOpcode() found full_trace.size=" + to_string(full_trace.size()) + " too low");
+                exitProcess();
+            }
+        }
 
         // Set gas refund for sstore opcode
         getVarFromCtx(ctx, false, ctx.rom.gasRefundOffset, auxScalar);

--- a/src/main_sm/fork_4/main/full_tracer.cpp
+++ b/src/main_sm/fork_4/main/full_tracer.cpp
@@ -1381,12 +1381,34 @@ zkresult FullTracer::onOpcode(Context &ctx, const RomCommand &cmd)
 
             prevTraceCall->gas_cost = prevTraceCall->gas - gasCTX;
         }
+        else if (prevTraceCall->depth != singleInfo.depth)
+        {
+            // Means opcode failed with error (ex: oog, invalidStaticTx...)
+            if (!prevTraceCall->error.empty())
+            {
+                prevTraceCall->gas_cost = prevTraceCall->gas;
+            }
+        }
         else
         {
             prevTraceCall->gas_cost = gasCost;
         }
 
         // cout << "info[info.size() - 1].gas_cost=" << info[info.size() - 1].gas_cost << endl;
+
+        // If gas cost is negative means gas has been added from a deeper context, it should be recalculated
+        if (prevTraceCall->gas_cost < 0)
+        {
+            if (full_trace.size() > 2)
+            {
+                prevTraceCall->gas_cost = full_trace[full_trace.size() - 2].gas - prevTraceCall->gas;
+            }
+            else
+            {
+                zklog.error("FullTracer::onOpcode() found full_trace.size=" + to_string(full_trace.size()) + " too low");
+                return ZKR_UNSPECIFIED;
+            }
+        }
 
         // Set gas refund for sstore opcode
         zkr = getVarFromCtx(ctx, false, ctx.rom.gasRefundOffset, auxScalar);

--- a/src/main_sm/fork_4/main/full_tracer.cpp
+++ b/src/main_sm/fork_4/main/full_tracer.cpp
@@ -874,7 +874,7 @@ zkresult FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);

--- a/src/main_sm/fork_5/main/full_tracer.cpp
+++ b/src/main_sm/fork_5/main/full_tracer.cpp
@@ -1444,12 +1444,34 @@ zkresult FullTracer::onOpcode(Context &ctx, const RomCommand &cmd)
 
             prevTraceCall->gas_cost = prevTraceCall->gas - gasCTX;
         }
+        else if (prevTraceCall->depth != singleInfo.depth)
+        {
+            // Means opcode failed with error (ex: oog, invalidStaticTx...)
+            if (!prevTraceCall->error.empty())
+            {
+                prevTraceCall->gas_cost = prevTraceCall->gas;
+            }
+        }
         else
         {
             prevTraceCall->gas_cost = gasCost;
         }
 
         // cout << "info[info.size() - 1].gas_cost=" << info[info.size() - 1].gas_cost << endl;
+
+        // If gas cost is negative means gas has been added from a deeper context, it should be recalculated
+        if (prevTraceCall->gas_cost < 0)
+        {
+            if (full_trace.size() > 2)
+            {
+                prevTraceCall->gas_cost = full_trace[full_trace.size() - 2].gas - prevTraceCall->gas;
+            }
+            else
+            {
+                zklog.error("FullTracer::onOpcode() found full_trace.size=" + to_string(full_trace.size()) + " too low");
+                return ZKR_UNSPECIFIED;
+            }
+        }
 
         // Set gas refund for sstore opcode
         zkr = getVarFromCtx(ctx, false, ctx.rom.gasRefundOffset, auxScalar);

--- a/src/main_sm/fork_5/main/full_tracer.cpp
+++ b/src/main_sm/fork_5/main/full_tracer.cpp
@@ -909,7 +909,7 @@ zkresult FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);

--- a/src/main_sm/fork_6/main/full_tracer.cpp
+++ b/src/main_sm/fork_6/main/full_tracer.cpp
@@ -1444,12 +1444,34 @@ zkresult FullTracer::onOpcode(Context &ctx, const RomCommand &cmd)
 
             prevTraceCall->gas_cost = prevTraceCall->gas - gasCTX;
         }
+        else if (prevTraceCall->depth != singleInfo.depth)
+        {
+            // Means opcode failed with error (ex: oog, invalidStaticTx...)
+            if (!prevTraceCall->error.empty())
+            {
+                prevTraceCall->gas_cost = prevTraceCall->gas;
+            }
+        }
         else
         {
             prevTraceCall->gas_cost = gasCost;
         }
 
         // cout << "info[info.size() - 1].gas_cost=" << info[info.size() - 1].gas_cost << endl;
+
+        // If gas cost is negative means gas has been added from a deeper context, it should be recalculated
+        if (prevTraceCall->gas_cost < 0)
+        {
+            if (full_trace.size() > 2)
+            {
+                prevTraceCall->gas_cost = full_trace[full_trace.size() - 2].gas - prevTraceCall->gas;
+            }
+            else
+            {
+                zklog.error("FullTracer::onOpcode() found full_trace.size=" + to_string(full_trace.size()) + " too low");
+                return ZKR_UNSPECIFIED;
+            }
+        }
 
         // Set gas refund for sstore opcode
         zkr = getVarFromCtx(ctx, false, ctx.rom.gasRefundOffset, auxScalar);

--- a/src/main_sm/fork_6/main/full_tracer.cpp
+++ b/src/main_sm/fork_6/main/full_tracer.cpp
@@ -909,7 +909,7 @@ zkresult FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);

--- a/src/main_sm/fork_7/main/full_tracer.cpp
+++ b/src/main_sm/fork_7/main/full_tracer.cpp
@@ -1616,7 +1616,7 @@ zkresult FullTracer::onFinishTx(Context &ctx, const RomCommand &cmd)
              (lastOpcodeCall.error.size() == 0) &&
              (response.full_trace.context.to != "0x") )
         {
-            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]);
+            lastOpcodeCall.gas_cost = lastOpcodeCall.gas - fr.toU64(ctx.pols.GAS[*ctx.pStep]) + lastOpcodeCall.gas_refund;
         }
 
         response.full_trace.steps.swap(full_trace);


### PR DESCRIPTION
- Adding `gas_refund` to very last opcode of a trace