### PR TITLE
Parametrizing arity of the Merkle Tree used in the BN128 Stark Recursive F proof

### DIFF
--- a/src/starkpil/fri/friProofC12.hpp
+++ b/src/starkpil/fri/friProofC12.hpp
@@ -3,6 +3,7 @@
 
 #include "goldilocks_base_field.hpp"
 #include "poseidon_goldilocks.hpp"
+#include "merkleTreeBN128.hpp"
 #include "fr.hpp"
 #include <vector>
 
@@ -14,7 +15,7 @@ public:
     std::vector<std::vector<Goldilocks::Element>> v;
     std::vector<std::vector<RawFr::Element>> mp;
 
-    MerkleProofC12(uint64_t nLinears, uint64_t elementsTree, void *pointer) : v(nLinears, std::vector<Goldilocks::Element>(1, Goldilocks::zero())), mp(elementsTree, std::vector<RawFr::Element>(16, RawFr::field.zero()))
+    MerkleProofC12(uint64_t nLinears, uint64_t elementsTree, void *pointer) : v(nLinears, std::vector<Goldilocks::Element>(1, Goldilocks::zero())), mp(elementsTree, std::vector<RawFr::Element>(MT_BN128_ARITY, RawFr::field.zero()))
     {
         for (uint64_t i = 0; i < nLinears; i++)
         {
@@ -23,7 +24,7 @@ public:
         RawFr::Element *mpCursor = (RawFr::Element *)&((Goldilocks::Element *)pointer)[nLinears];
         for (uint64_t j = 0; j < elementsTree; j++)
         {
-            std::memcpy(&mp[j][0], &mpCursor[j * 16], 16 * sizeof(RawFr::Element));
+            std::memcpy(&mp[j][0], &mpCursor[j * MT_BN128_ARITY], MT_BN128_ARITY * sizeof(RawFr::Element));
         }
     };
     ordered_json merkleProof2json()

--- a/src/starkpil/merkleTree/merkleTreeBN128.hpp
+++ b/src/starkpil/merkleTree/merkleTreeBN128.hpp
@@ -6,9 +6,8 @@
 #include "goldilocks_base_field.hpp"
 #include "poseidon_opt.hpp"
 
-#define MT_BN128_ARITY 16
+#define MT_BN128_ARITY 4
 #define GOLDILOCKS_ELEMENTS 3
-#define HASH_SIZE 4
 
 class MerkleTreeBN128
 {

--- a/src/starkpil/starkRecursiveF/starkRecursiveF.hpp
+++ b/src/starkpil/starkRecursiveF/starkRecursiveF.hpp
@@ -19,7 +19,6 @@
 #include "steps.hpp"
 #include "chelpers.hpp"
 
-#define BN128_ARITY 16
 #define STARK_RECURSIVE_F_NUM_TREES 5
 
 class StarkRecursiveF
@@ -73,16 +72,16 @@ public:
     uint64_t getConstTreeSize(uint64_t n, uint64_t pol)
     {
         uint n_tmp = n;
-        uint64_t nextN = floor(((double)(n_tmp - 1) / BN128_ARITY) + 1);
-        uint64_t acc = nextN * BN128_ARITY;
+        uint64_t nextN = floor(((double)(n_tmp - 1) / MT_BN128_ARITY) + 1);
+        uint64_t acc = nextN * MT_BN128_ARITY;
         while (n_tmp > 1)
         {
             // FIll with zeros if n nodes in the leve is not even
             n_tmp = nextN;
-            nextN = floor((n_tmp - 1) / BN128_ARITY) + 1;
+            nextN = floor((n_tmp - 1) / MT_BN128_ARITY) + 1;
             if (n_tmp > 1)
             {
-                acc += nextN * 16;
+                acc += nextN * MT_BN128_ARITY;
             }
             else
             {
@@ -98,16 +97,16 @@ public:
     uint64_t getTreeSize(uint64_t n, uint64_t pol)
     {
         uint n_tmp = n;
-        uint64_t nextN = floor(((double)(n_tmp - 1) / BN128_ARITY) + 1);
-        uint64_t acc = nextN * BN128_ARITY;
+        uint64_t nextN = floor(((double)(n_tmp - 1) / MT_BN128_ARITY) + 1);
+        uint64_t acc = nextN * MT_BN128_ARITY;
         while (n_tmp > 1)
         {
             // FIll with zeros if n nodes in the leve is not even
             n_tmp = nextN;
-            nextN = floor((n_tmp - 1) / BN128_ARITY) + 1;
+            nextN = floor((n_tmp - 1) / MT_BN128_ARITY) + 1;
             if (n_tmp > 1)
             {
-                acc += nextN * 16;
+                acc += nextN * MT_BN128_ARITY;
             }
             else
             {

--- a/src/starkpil/transcript/transcriptBN128.cpp
+++ b/src/starkpil/transcript/transcriptBN128.cpp
@@ -25,7 +25,7 @@ void TranscriptBN128::_add1(RawFr::Element input)
 {
     pending.push_back(input);
     out.clear();
-    if (pending.size() == 16)
+    if (pending.size() == TRANSCRIPT_BN128_ARITY)
     {
         _updateState();
     }
@@ -76,7 +76,7 @@ uint64_t TranscriptBN128::getFields1()
 
 void TranscriptBN128::_updateState()
 {
-    while (pending.size() < 16)
+    while (pending.size() < TRANSCRIPT_BN128_ARITY)
     {
         pending.push_back(RawFr::field.zero());
     }

--- a/src/starkpil/transcript/transcriptBN128.hpp
+++ b/src/starkpil/transcript/transcriptBN128.hpp
@@ -6,9 +6,7 @@
 #include <cstring>
 #include "goldilocks_base_field.hpp"
 
-#define TRANSCRIPT_STATE_SIZE 4
-#define TRANSCRIPT_PENDING_SIZE 8
-#define TRANSCRIPT_OUT_SIZE 12
+#define TRANSCRIPT_BN128_ARITY 16
 
 // TODO: Pending to review and re-factor
 class TranscriptBN128


### PR DESCRIPTION
Currently, the merkle trees used in the BN128 Stark RecursiveF proof have an arity of 16. This was optimal from the prover performance point of view. The problem is that right now we are quite close to the next power of 2 (our final circuit has 16.509M and 2^24 = 16.777M), and with Feijoa chances are that we may surpass that value. 
To mitigate this problem, this PR parametrizes the arity of the merkle tree to be any power of two. The reasoning behind this is that the `VerifyMerkleHash` circuit was originally optimized for Groth16 by adding a lot of sums, which is not efficient for Fflonk, our current proving system. 
This PR not only adds the parametrization, but proposes changing the arity to 4, which leads to a 4M constraints reduction on the final circuit. The proof time will not be impacted much, since the extra proving time added to the StarkRecursiveF will be compensated in the Fflonk proof.