### PR TITLE
Reusing prover memory

### DIFF
--- a/src/prover/prover.cpp
+++ b/src/prover/prover.cpp
@@ -92,7 +92,38 @@ Prover::Prover(Goldilocks &fr,
 
             // Allocate an area of memory, mapped to file, to store all the committed polynomials,
             // and create them using the allocated address
-            uint64_t polsSize = _starkInfo.mapTotalN * sizeof(Goldilocks::Element) + _starkInfo.mapSectionsN.section[eSection::cm3_2ns] * (1 << _starkInfo.starkStruct.nBitsExt) * sizeof(Goldilocks::Element);
+
+            polsSize = _starkInfo.mapTotalN * sizeof(Goldilocks::Element);
+            if( _starkInfo.mapOffsets.section[eSection::cm1_2ns] < _starkInfo.mapOffsets.section[eSection::tmpExp_n]) optimizeMemoryNTTCommitPols = true;
+            for(uint64_t i = 1; i <= 3; ++i) {
+                std::string currentSection = "cm" + to_string(i) + "_n";
+                std::string nextSectionExtended = i == 1 && optimizeMemoryNTTCommitPols ? "tmpExp_n" : "cm" + to_string(i + 1) + "_2ns";
+                uint64_t nttHelperSize = _starkInfo.mapSectionsN.section[string2section(currentSection)] * (1 << _starkInfo.starkStruct.nBitsExt) * sizeof(Goldilocks::Element);
+                uint64_t currentSectionStart = _starkInfo.mapOffsets.section[string2section(currentSection)] * sizeof(Goldilocks::Element);
+                if (i == 3 && currentSectionStart > nttHelperSize) optimizeMemoryNTT = true;
+                uint64_t nttHelperBufferStart = optimizeMemoryNTT ? 0 : _starkInfo.mapOffsets.section[string2section(nextSectionExtended)] * sizeof(Goldilocks::Element);
+                uint64_t totalMemSize = nttHelperBufferStart + nttHelperSize;
+                if(totalMemSize > polsSize) {
+                    polsSize = totalMemSize;
+                }
+            }
+
+            // Check that we have enough memory for stage2 H1H2 helpers (if not add memory)
+            uint64_t stage2Start = _starkInfo.mapOffsets.section[cm2_2ns] * sizeof(Goldilocks::Element);
+            uint64_t buffTransposedH1H2Size = 4 * _starkInfo.puCtx.size() * ((1 << _starkInfo.starkStruct.nBits) * FIELD_EXTENSION + 8);
+            uint64_t buffHelperH1H2Size = (1 << _starkInfo.starkStruct.nBits) * _starkInfo.puCtx.size();
+            uint64_t buffStage2HelperSize = (buffTransposedH1H2Size + buffHelperH1H2Size)*sizeof(Goldilocks::Element);
+            if(stage2Start + buffStage2HelperSize > polsSize) {
+                polsSize = stage2Start + buffStage2HelperSize;
+            }
+            
+            // Check that we have enough memory for stage3 (Z) helpers (if not add memory)
+            uint64_t stage3Start = _starkInfo.mapOffsets.section[cm3_2ns] * sizeof(Goldilocks::Element);
+            uint64_t tot_pols = 3 * (_starkInfo.puCtx.size() + _starkInfo.peCtx.size() + _starkInfo.ciCtx.size());
+            uint64_t buffStage3HelperSize = (tot_pols*((1 << _starkInfo.starkStruct.nBits) * FIELD_EXTENSION + 8)) * sizeof(Goldilocks::Element);
+            if(stage3Start + buffStage3HelperSize > polsSize) {
+                polsSize = stage3Start + buffStage3HelperSize;
+            }
 
             zkassert(_starkInfo.mapSectionsN.section[eSection::cm1_2ns] * sizeof(Goldilocks::Element) <= polsSize - _starkInfo.mapSectionsN.section[eSection::cm2_2ns] * sizeof(Goldilocks::Element));
 
@@ -122,6 +153,8 @@ Prover::Prover(Goldilocks &fr,
             pAddressStarksRecursiveF = (void *)malloc(_starkInfoRecursiveF.mapTotalN * sizeof(Goldilocks::Element));
 
             starkBatch = new Starks(config, {config.zkevmConstPols, config.mapConstPolsFile, config.zkevmConstantsTree, config.zkevmStarkInfo, config.zkevmCHelpers}, pAddress);
+            if(optimizeMemoryNTT) starkBatch->optimizeMemoryNTT = true;
+            if(optimizeMemoryNTTCommitPols) starkBatch->optimizeMemoryNTTCommitPols = true;
             starkBatchC12a = new Starks(config, {config.c12aConstPols, config.mapConstPolsFile, config.c12aConstantsTree, config.c12aStarkInfo, config.c12aCHelpers}, pAddress);
             starkBatchRecursive1 = new Starks(config, {config.recursive1ConstPols, config.mapConstPolsFile, config.recursive1ConstantsTree, config.recursive1StarkInfo, config.recursive1CHelpers}, pAddress);
             starkBatchRecursive2 = new Starks(config, {config.recursive2ConstPols, config.mapConstPolsFile, config.recursive2ConstantsTree, config.recursive2StarkInfo, config.recursive2CHelpers}, pAddress);
@@ -155,8 +188,6 @@ Prover::~Prover()
         delete pGroth16;
         delete pZkey;
         delete pZkeyHeader;
-
-        uint64_t polsSize = starkBatch->starkInfo.mapTotalN * sizeof(Goldilocks::Element) + starkBatch->starkInfo.mapSectionsN.section[eSection::cm1_n] * (1 << starkBatch->starkInfo.starkStruct.nBits) * FIELD_EXTENSION * sizeof(Goldilocks::Element);
 
         // Unmap committed polynomials address
         if (config.zkevmCmPols.size() > 0)
@@ -1075,23 +1106,23 @@ void Prover::executeBatch (ProverRequest *pProverRequest)
 
     // Allocate an area of memory, mapped to file, to store all the committed polynomials,
     // and create them using the allocated address
-    uint64_t polsSize = PROVER_FORK_NAMESPACE::CommitPols::pilSize();
+    uint64_t commitPolsSize = PROVER_FORK_NAMESPACE::CommitPols::pilSize();
     void *pExecuteAddress = NULL;
 
     if (config.zkevmCmPols.size() > 0)
     {
-        pExecuteAddress = mapFile(config.zkevmCmPols, polsSize, true);
-        zklog.info("Prover::executeBatch() successfully mapped " + to_string(polsSize) + " bytes to file " + config.zkevmCmPols);
+        pExecuteAddress = mapFile(config.zkevmCmPols, commitPolsSize, true);
+        zklog.info("Prover::execute() successfully mapped " + to_string(commitPolsSize) + " bytes to file " + config.zkevmCmPols);
     }
     else
     {
-        pExecuteAddress = calloc(polsSize, 1);
+        pExecuteAddress = calloc(commitPolsSize, 1);
         if (pExecuteAddress == NULL)
         {
-            zklog.error("Prover::executeBatch() failed calling malloc() of size " + to_string(polsSize));
+            zklog.error("Prover::execute() failed calling malloc() of size " + to_string(commitPolsSize));
             exitProcess();
         }
-        zklog.info("Prover::executeBatch() successfully allocated " + to_string(polsSize) + " bytes");
+        zklog.info("Prover::execute() successfully allocated " + to_string(commitPolsSize) + " bytes");
     }
 
     /************/
@@ -1142,7 +1173,7 @@ void Prover::executeBatch (ProverRequest *pProverRequest)
     // Unmap committed polynomials address
     if (config.zkevmCmPols.size() > 0)
     {
-        unmapFile(pExecuteAddress, polsSize);
+        unmapFile(pExecuteAddress, commitPolsSize);
     }
     else
     {
@@ -1189,23 +1220,23 @@ void Prover::executeBlobInner (ProverRequest *pProverRequest)
 
     // Allocate an area of memory, mapped to file, to store all the committed polynomials,
     // and create them using the allocated address
-    uint64_t polsSize = PROVER_FORK_NAMESPACE::CommitPols::pilSize();
+    uint64_t commitPolsSize = PROVER_FORK_NAMESPACE::CommitPols::pilSize();
     void *pExecuteAddress = NULL;
 
     if (config.zkevmCmPols.size() > 0)
     {
-        pExecuteAddress = mapFile(config.zkevmCmPols, polsSize, true);
-        zklog.info("Prover::executeBlobInner() successfully mapped " + to_string(polsSize) + " bytes to file " + config.zkevmCmPols);
+        pExecuteAddress = mapFile(config.zkevmCmPols, commitPolsSize, true);
+        zklog.info("Prover::executeBlobInner() successfully mapped " + to_string(commitPolsSize) + " bytes to file " + config.zkevmCmPols);
     }
     else
     {
-        pExecuteAddress = calloc(polsSize, 1);
+        pExecuteAddress = calloc(commitPolsSize, 1);
         if (pExecuteAddress == NULL)
         {
-            zklog.error("Prover::executeBlobInner() failed calling malloc() of size " + to_string(polsSize));
+            zklog.error("Prover::executeBlobInner() failed calling malloc() of size " + to_string(commitPolsSize));
             exitProcess();
         }
-        zklog.info("Prover::executeBlobInner() successfully allocated " + to_string(polsSize) + " bytes");
+        zklog.info("Prover::executeBlobInner() successfully allocated " + to_string(commitPolsSize) + " bytes");
     }
 
     /************/
@@ -1256,7 +1287,7 @@ void Prover::executeBlobInner (ProverRequest *pProverRequest)
     // Unmap committed polynomials address
     if (config.zkevmCmPols.size() > 0)
     {
-        unmapFile(pExecuteAddress, polsSize);
+        unmapFile(pExecuteAddress, commitPolsSize);
     }
     else
     {

--- a/src/prover/prover.hpp
+++ b/src/prover/prover.hpp
@@ -62,6 +62,9 @@ private:
     void *pAddress = NULL;
     void *pAddressStarksRecursiveF = NULL;
     int protocolId;
+    uint64_t polsSize;
+    bool optimizeMemoryNTT = false;
+    bool optimizeMemoryNTTCommitPols = false;
 public:
     const Config &config;
     sem_t pendingRequestSem; // Semaphore to wakeup prover thread when a new request is available

--- a/src/starkpil/starks.hpp
+++ b/src/starkpil/starks.hpp
@@ -33,6 +33,8 @@ class Starks
 public:
     const Config &config;
     StarkInfo starkInfo;
+    bool optimizeMemoryNTT = false;
+    bool optimizeMemoryNTTCommitPols = false;
 
 private:
     void *pConstPolsAddress;
@@ -63,6 +65,7 @@ private:
     Goldilocks::Element *cm4_2ns;
     Goldilocks::Element *p_q_2ns;
     Goldilocks::Element *p_f_2ns;
+    Goldilocks::Element *p_tmpExp_n;
     Goldilocks::Element *pBuffer;
 
     void *pAddress;
@@ -175,6 +178,7 @@ public:
         p_cm2_n = &mem[starkInfo.mapOffsets.section[eSection::cm2_n]];
         p_cm3_2ns = &mem[starkInfo.mapOffsets.section[eSection::cm3_2ns]];
         p_cm3_n = &mem[starkInfo.mapOffsets.section[eSection::cm3_n]];
+        p_tmpExp_n = &mem[starkInfo.mapOffsets.section[eSection::tmpExp_n]];
         cm4_2ns = &mem[starkInfo.mapOffsets.section[eSection::cm4_2ns]];
         p_q_2ns = &mem[starkInfo.mapOffsets.section[eSection::q_2ns]];
         p_f_2ns = &mem[starkInfo.mapOffsets.section[eSection::f_2ns]];


### PR DESCRIPTION
This PR reduces 50GB (of  325GB) of the memory used for storing the polynomials. This represents around a 15% reduction. This is achieved by applying two different reductions. Before diving into it, here is a recap of how is memory distributed and used right now:
`| cm1_n | cm2_n | cm3_n | cm4_n | tmpExp_n | cm1_2ns | cm2_2ns | cm3_2ns | cm4_2ns | q_2ns | f_2ns | extra memory`
When calculating a NTT for a certain stage, we need a buffer that has size `NExtended * ncols * sizeof(Goldilocks)` that allows us to do the transpose and perform the operations. To obtain this memory we use the following:
- For the first stage, we use all the memory starting from cm2_2ns 
- For the second one, we use all the memory starting from cm3_2ns
- For the third stage, we use all the memory starting from cm4_2ns

What happens is that we need to add 50GB of extra memory at the end (20 GB for the first stage and 30 GB extra for the third) so that we don't exceed the limits of the reserved memory. To solve this issue, two separate tricks has been used to reduce the memory of each case.

Regarding the third stage, we rely on the fact that at the point of time in which we are calculating the NTT, values from the polynomials of first and second stage in the basefield will not be used again, since the Q polynomial and FRI polynomial are all calculated with polynomials in the extended domain (_2ns). Therefore, if the helper fits in `| cm1_n | cm2_n |` (which will not always happen in smaller starks such as the compressor or the recursives, but happens in the zkevm one), we can reuse that space of memory. This saves us the first 30 GB.

Regarding the first stage, we rely on the fact that on this first stage we are not calculating any expression, and therefore we do not set any value in `tmpExp_n`. Therefore, we can switch the order of the buffer from `| tmpExp_n | cm1_2ns | cm2_2ns | ` to | `cm1_2ns | tmpExp_n | cm2_2ns | `, which allows us to use as a starting point of the NTT buffer helper for this first stage where tmpExp_n buffer would start. This has been implemented with backwards compatibility by only applying this optimitzation whenever the order defined in the starkInfo allows it.

Keeping in mind everything mentioned above, code logic have been added so that the prover only reserves the memory it needs. Additionally, when calculating the memory needed, the code also checks that the buffers helpers used for calculating H1H2 in the stage2 and Z in the stage3 fit properly. 
