### PR TITLE
Flexible Associative Cache Upgrade

### DIFF
--- a/src/config/definitions.hpp
+++ b/src/config/definitions.hpp
@@ -61,6 +61,7 @@
 #define LOG_FULL_TRACER_ON_ERROR
 //#define LOG_TX_HASH
 //#define LOG_INPUT
+//#define LOG_ASSOCIATIVE_CACHE
 //LOG_SMT_KEY_DETAILS
 
 /* Prover defines */

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -69,7 +69,7 @@ void DatabaseMTAssociativeCache::postConstruct(int log2IndexesSize_, int log2Cac
     if(indexes != NULL) delete[] indexes;
     indexes = new uint32_t[indexesSize];
     //initialization of indexes array
-    uint32_t initValue = UINT32_MAX-cacheSize-(uint32_t)1;
+    uint32_t initValue = UINT32_MAX-cacheSize;
     #pragma omp parallel for schedule(static) num_threads(4)
     for (size_t i = 0; i < indexesSize; i++)
     {

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -327,7 +327,7 @@ bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], ve
     //
     //  Statistics
     //
-    if (attempts<<40 == 0)
+    if (attempts<<34 == 0)
     {
         zklog.info("DatabaseMTAssociativeCache::findKey() name=" + name + " indexesSize=" + to_string(indexesSize) + " cacheSize=" + to_string(cacheSize) + " attempts=" + to_string(attempts) + " hits=" + to_string(hits) + " hit ratio=" + to_string(double(hits) * 100.0 / double(zkmax(attempts, 1))) + "%");
         if(auxBufferKeysValues.size()>0){

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -332,9 +332,10 @@ bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], ve
     //
     for(int i=0; i<auxBufferKeysValues.size(); i+=17){
         if( auxBufferKeysValues[i].fe == key[0].fe &&
-            auxBufferKeysValues[i+1].fe == key[1].fe &&
-            auxBufferKeysValues[i+2].fe == key[2].fe &&
-            auxBufferKeysValues[i+3].fe == key[3].fe){
+            auxBufferKeysValues[i+1].fe == key[0].fe &&
+            auxBufferKeysValues[i+2].fe == key[1].fe &&
+            auxBufferKeysValues[i+3].fe == key[2].fe &&
+            auxBufferKeysValues[i+4].fe == key[3].fe){
             ++hits;
             value.resize(12);
             value[0] = auxBufferKeysValues[i+5];

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -304,7 +304,7 @@ void DatabaseMTAssociativeCache::addKeyValue_(const Goldilocks::Element (&key)[4
     //
     // Add value
     //
-    isValidKey[cacheIndex] = true;
+    if(!isValidKey[cacheIndex]) isValidKey[cacheIndex] = true; //avoid modify if uneccessary (cache effects)
     keys[cacheIndexKey + 0].fe = key[0].fe;
     keys[cacheIndexKey + 1].fe = key[1].fe;
     keys[cacheIndexKey + 2].fe = key[2].fe;

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -27,7 +27,8 @@ DatabaseMTAssociativeCache::DatabaseMTAssociativeCache()
     auxBufferKeysValues.clear();
 };
 
-DatabaseMTAssociativeCache::DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t cacheSize_, string name_)
+DatabaseMTAssociativeCache::DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t cacheSize_, string name_) :
+    indexes(NULL), keys(NULL), values(NULL), currentCacheIndex(0), attempts(0), hits(0), name(name_)
 {
     postConstruct(log2IndexesSize_, cacheSize_, name_);
 };
@@ -313,7 +314,7 @@ void DatabaseMTAssociativeCache::forcedInsertion(uint32_t (&usedRawCacheIndexes)
         }
         return;
     }else{
-        indexes[minRawCacheIndex] = inputRawCacheIndex;
+        indexes[(uint32_t)(inputKey[pos].fe & indexesMask)] = inputRawCacheIndex;
         usedRawCacheIndexes[iters] = minRawCacheIndex; //new cache element to add in the indexes table
         forcedInsertion(usedRawCacheIndexes, iters, update);
     }

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -207,7 +207,6 @@ bool DatabaseMTAssociativeCache::extractKeyValue_(const Goldilocks::Element (&ke
 }
 
 bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
-    bool found = false;    
     //
     // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
     // for this reason this search is not optimized at all
@@ -235,11 +234,11 @@ bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks:
                 value[11] = auxBufferKeysValues[i+16];
                 //erase the value
                 auxBufferKeysValues.erase(auxBufferKeysValues.begin() + i, auxBufferKeysValues.begin() + i + 17);   
-                found=true;
+                return true;
             }
         } 
     }
-    return found;
+    return false;
 }
 
 void DatabaseMTAssociativeCache::addKeyValue_(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update)

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -465,7 +465,6 @@ void DatabaseMTAssociativeCache::forcedInsertion_(uint32_t (&usedRawCacheIndexes
 
 bool DatabaseMTAssociativeCache::findKey_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value, bool &reinsert)
 {
-    bool found = false;
     reinsert = false;
     //
     // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
@@ -495,51 +494,48 @@ bool DatabaseMTAssociativeCache::findKey_(const Goldilocks::Element (&key)[4], v
                 value[9] = auxBufferKeysValues[i+14];
                 value[10] = auxBufferKeysValues[i+15];
                 value[11] = auxBufferKeysValues[i+16];
-                found=true;
                 if(distanceFromCurrentCacheIndex_((uint32_t)(auxBufferKeysValues[i].fe)) > cacheSizeDiv2){
                     reinsert = true;
                 }
-                break;
+                return true;
             }
         } 
     }
     //
     // Look at the circulant buffer
     //
-    if(!found){
-        for (int i = 0; i < 4; i++)
-        {
-            uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
-            if (hasExpired_(cacheIndexRaw)) continue;
-            
-            uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
-            uint32_t cacheIndexKey = cacheIndex * 4;
+    for (int i = 0; i < 4; i++)
+    {
+        uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
+        if (hasExpired_(cacheIndexRaw)) continue;
+        
+        uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
+        uint32_t cacheIndexKey = cacheIndex * 4;
 
-            if (keys[cacheIndexKey + 0].fe == key[0].fe &&
-                keys[cacheIndexKey + 1].fe == key[1].fe &&
-                keys[cacheIndexKey + 2].fe == key[2].fe &&
-                keys[cacheIndexKey + 3].fe == key[3].fe)
-            {
-                uint32_t cacheIndexValue = cacheIndex * 12;
-                value.resize(12);
-                value[0] = values[cacheIndexValue];
-                value[1] = values[cacheIndexValue + 1];
-                value[2] = values[cacheIndexValue + 2];
-                value[3] = values[cacheIndexValue + 3];
-                value[4] = values[cacheIndexValue + 4];
-                value[5] = values[cacheIndexValue + 5];
-                value[6] = values[cacheIndexValue + 6];
-                value[7] = values[cacheIndexValue + 7];
-                value[8] = values[cacheIndexValue + 8];
-                value[9] = values[cacheIndexValue + 9];
-                value[10] = values[cacheIndexValue + 10];
-                value[11] = values[cacheIndexValue + 11];
-                found=true;
-                if(distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSizeDiv2){
-                    reinsert = true;
-                }
+        if (keys[cacheIndexKey + 0].fe == key[0].fe &&
+            keys[cacheIndexKey + 1].fe == key[1].fe &&
+            keys[cacheIndexKey + 2].fe == key[2].fe &&
+            keys[cacheIndexKey + 3].fe == key[3].fe)
+        {
+            uint32_t cacheIndexValue = cacheIndex * 12;
+            value.resize(12);
+            value[0] = values[cacheIndexValue];
+            value[1] = values[cacheIndexValue + 1];
+            value[2] = values[cacheIndexValue + 2];
+            value[3] = values[cacheIndexValue + 3];
+            value[4] = values[cacheIndexValue + 4];
+            value[5] = values[cacheIndexValue + 5];
+            value[6] = values[cacheIndexValue + 6];
+            value[7] = values[cacheIndexValue + 7];
+            value[8] = values[cacheIndexValue + 8];
+            value[9] = values[cacheIndexValue + 9];
+            value[10] = values[cacheIndexValue + 10];
+            value[11] = values[cacheIndexValue + 11];
+            if(distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSizeDiv2){
+                reinsert = true;
             }
+            return true;
         }
     }
-    return found;
+    return false;
 }

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -13,9 +13,9 @@ class DatabaseMTAssociativeCache
     private:
         recursive_mutex mlock;
 
-        int log2IndexesSize;
+        uint32_t log2IndexesSize;
         uint32_t indexesSize;
-        int log2CacheSize;
+        uint32_t log2CacheSize;
         uint32_t cacheSize;
 
         uint32_t *indexes;
@@ -27,18 +27,18 @@ class DatabaseMTAssociativeCache
         uint64_t hits;
         string name;
 
-        uint64_t indexesMask;
-        uint64_t cacheMask;
+        uint32_t indexesMask;
+        uint32_t cacheMask;
 
         vector<Goldilocks::Element> auxBufferKeysValues;
 
     public:
 
         DatabaseMTAssociativeCache();
-        DatabaseMTAssociativeCache(int log2IndexesSize_, int log2CacheSize_, string name_);
+        DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
         ~DatabaseMTAssociativeCache();
 
-        void postConstruct(int log2IndexesSize_, int log2CacheSize_, string name_);
+        void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
         void addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
         bool findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
         inline bool enabled() const { return (log2IndexesSize > 0); };
@@ -54,8 +54,8 @@ class DatabaseMTAssociativeCache
     private:
         inline bool emptyCacheSlot(uint32_t cacheIndexRaw) const { 
             return (currentCacheIndex > cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
-            (currentCacheIndex <= cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1 > cacheSize);
+            (currentCacheIndex <= cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex > cacheSize - 1);
          };
-        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], int &iters, bool update);
+        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], uint32_t &iters, bool update);
 };
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -55,6 +55,6 @@ class DatabaseMTAssociativeCache
             return (currentCacheIndex >= cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
             (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1 > cacheSize);
          };
-        void forcedInsertion(vector<uint32_t> &usedRawCacheIndexes, int &iters);
+        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], int &iters);
 };
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -58,5 +58,20 @@ class DatabaseMTAssociativeCache
             (currentCacheIndex <= cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex > cacheSize - 1);
          };
         void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], uint32_t &iters, bool update);
+        inline void cleanAuxBufferKeysValues(){
+            auto it = auxBufferKeysValues.begin();
+            while (it < auxBufferKeysValues.end()) {
+                if (emptyCacheSlot(static_cast<uint32_t>(it->fe))) {
+                    auto next_it = (std::distance(it, auxBufferKeysValues.end()) >= 17) ? it + 17 : auxBufferKeysValues.end();
+                    it = auxBufferKeysValues.erase(it, next_it);
+                } else {
+                    if (std::distance(it, auxBufferKeysValues.end()) >= 17) {
+                        it += 17;
+                    } else {
+                        it = auxBufferKeysValues.end();
+                    }
+                }
+            }
+        };
 };
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -30,6 +30,7 @@ class DatabaseMTAssociativeCache
         uint64_t indexesMask;
         uint64_t cacheMask;
 
+        vector<Goldilocks::Element> auxBufferKeysValues;
 
     public:
 
@@ -54,6 +55,6 @@ class DatabaseMTAssociativeCache
             return (currentCacheIndex >= cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
             (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex > cacheSize);
          };
-        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[10], int &iters);
+        void forcedInsertion(vector<uint32_t> &usedRawCacheIndexes, int &iters);
 };
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -78,17 +78,19 @@ class DatabaseMTAssociativeCache
 
 void DatabaseMTAssociativeCache::addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update){
     // This wrapper is used to avoid the necessity of using lock_guard within the addKeyValue_ function
-    unique_lock<shared_mutex> lock(mlock);
+    mlock.lock();
     addKeyValue_(key, value, update);
+    mlock.unlock();
 }
 bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
     bool reinsert=false;
     bool found=false;
-    {
-        shared_lock<shared_mutex> lock(mlock);
-        found = findKey_(key, value, reinsert);
-    }
-    if(reinsert){
+    
+    mlock.lock_shared();
+    found = findKey_(key, value, reinsert);
+    mlock.unlock_shared();
+
+if(reinsert){
         unique_lock<shared_mutex> lock(mlock);
         vector<Goldilocks::Element> values_;
 

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -45,7 +45,8 @@ class DatabaseMTAssociativeCache
         DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_ = "associative_cache");
         DatabaseMTAssociativeCache(uint64_t cacheBytes_, string name_ = "associative_cache");
         ~DatabaseMTAssociativeCache();
-        void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
+        void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_= "associative_cache");
+        void postConstruct(uint64_t cacheBytes_, string name_ = "associative_cache");
         void clear();
         
         inline void addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -4,6 +4,7 @@
 #include "goldilocks_base_field.hpp"
 #include <nlohmann/json.hpp>
 #include <mutex>
+#include <shared_mutex>
 #include "zklog.hpp"
 #include "zkmax.hpp"
 
@@ -11,8 +12,8 @@ using namespace std;
 class DatabaseMTAssociativeCache
 {
     private:
-        recursive_mutex mlock;
-
+        shared_mutex mlock;
+        
         uint32_t log2IndexesSize;
         uint32_t indexesSize;
         uint32_t log2CacheSize;

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -18,9 +18,11 @@ class DatabaseMTAssociativeCache
         uint32_t indexesSize;
         uint32_t log2CacheSize;
         uint32_t cacheSize;
+        uint32_t cacheSizeDiv2;
 
         uint32_t *indexes;
         Goldilocks::Element *keys;
+        bool *isValidKey;
         Goldilocks::Element *values;
         uint32_t currentCacheIndex; 
 
@@ -38,30 +40,83 @@ class DatabaseMTAssociativeCache
         DatabaseMTAssociativeCache();
         DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
         ~DatabaseMTAssociativeCache();
-
         void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
-        void addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
-        bool findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
+        
+        inline void addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
+        inline bool findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
+
         inline bool enabled() const { return (log2IndexesSize > 0); };
         inline uint32_t getCacheSize()  const { return cacheSize; };
         inline uint32_t getIndexesSize() const { return indexesSize; };
         inline uint32_t getAuxBufferKeysValuesSize() const { return auxBufferKeysValues.size(); };
-        inline void clear(){
-            if(enabled()){
-                postConstruct(log2IndexesSize, log2CacheSize, name);                
-            }
-        }
+        inline void clear();
 
     private:
-        inline bool emptyCacheSlot(uint32_t cacheIndexRaw) const { 
-            return (currentCacheIndex > cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
-            (currentCacheIndex <= cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex > cacheSize - 1);
+        bool findKey_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value, bool &reinsert);
+        void addKeyValue_(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
+        bool extractKeyValue_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
+        
+        inline bool isEmptySlot(uint32_t cacheIndexRaw) const { 
+            return  !isValidKey[cacheIndexRaw & cacheMask] || distanceToCurrentCacheIndex(cacheIndexRaw) > cacheSize ;
+         };
+        inline uint32_t distanceToCurrentCacheIndex(uint32_t cacheIndexRaw) const {
+            if(currentCacheIndex == cacheIndexRaw) return UINT32_MAX; //it should be UINT32_MAX + 1 but is out of range
+            return (currentCacheIndex > cacheIndexRaw) ? currentCacheIndex - cacheIndexRaw : UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1;
          };
         void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], uint32_t &iters, bool update);
-        inline void cleanAuxBufferKeysValues(){
+        inline void cleanAuxBufferKeysValues();
+};
+
+void DatabaseMTAssociativeCache::addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update){
+    //This wrapper is used to aviod using the lock_guard inside the addKeyValue_ function
+    shared_lock<shared_mutex> lock(mlock);
+    addKeyValue_(key, value, update);
+}
+bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
+    bool reinsert=false;
+    bool found=false;
+    {
+        shared_lock<shared_mutex> lock(mlock);
+        found = findKey_(key, value, reinsert);
+    }
+    if(reinsert){
+        unique_lock<shared_mutex> lock(mlock);
+        vector<Goldilocks::Element> values_;
+        bool found = extractKeyValue_(key, values_);
+        //I retrive the values againg (values_) to prevent situations in which the values could have been modified by another thread betxeen the findKey_ and the addKeyValue_
+        if(found) addKeyValue_(key, values_, false);
+    }
+
+#ifdef LOG_CACHE
+    mlock.lock();
+    attempts++; 
+    if(found){
+        hits++;
+    }
+    mlock.unlock();
+    //
+    //  Statistics
+    //
+    if (attempts<<34 == 0)
+    {
+        zklog.info("DatabaseMTAssociativeCache::findKey() name=" + name + " indexesSize=" + to_string(indexesSize) + " cacheSize=" + to_string(cacheSize) + " attempts=" + to_string(attempts) + " hits=" + to_string(hits) + " hit ratio=" + to_string(double(hits) * 100.0 / double(zkmax(attempts, 1))) + "%");
+        if(auxBufferKeysValues.size()>0){
+            zklog.warning("DatabaseMTAssociativeCache using auxBufferKeysValues" + to_string(auxBufferKeysValues.size()));
+        }
+    }
+#endif
+
+    return found;
+}
+void DatabaseMTAssociativeCache::clear(){
+    memset(isValidKey, 0, cacheSize * sizeof(bool));
+    auxBufferKeysValues.clear();
+    currentCacheIndex = 0;
+}
+void DatabaseMTAssociativeCache::cleanAuxBufferKeysValues(){
             auto it = auxBufferKeysValues.begin();
             while (it < auxBufferKeysValues.end()) {
-                if (emptyCacheSlot(static_cast<uint32_t>(it->fe))) {
+                if (isEmptySlot(static_cast<uint32_t>(it->fe))) {
                     auto next_it = (std::distance(it, auxBufferKeysValues.end()) >= 17) ? it + 17 : auxBufferKeysValues.end();
                     it = auxBufferKeysValues.erase(it, next_it);
                 } else {
@@ -73,5 +128,4 @@ class DatabaseMTAssociativeCache
                 }
             }
         };
-};
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -53,7 +53,7 @@ class DatabaseMTAssociativeCache
     private:
         inline bool emptyCacheSlot(uint32_t cacheIndexRaw) const { 
             return (currentCacheIndex >= cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
-            (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex > cacheSize);
+            (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1 > cacheSize);
          };
         void forcedInsertion(vector<uint32_t> &usedRawCacheIndexes, int &iters);
 };

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -24,7 +24,7 @@ class DatabaseMTAssociativeCache
         Goldilocks::Element *keys;
         bool *isValidKey;
         Goldilocks::Element *values;
-        uint32_t currentCacheIndex; //next index to be used acts as a clock for the cache
+        uint32_t currentCacheIndex; //next index to be used (acts as a clock for the cache)
 
 #ifdef LOG_ASSOCIATIVE_CACHE
         uint64_t attempts;

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -91,13 +91,15 @@ bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], ve
     mlock.unlock_shared();
 
 if(reinsert){
-        unique_lock<shared_mutex> lock(mlock);
+        mlock.lock();
         vector<Goldilocks::Element> values_;
 
         bool foundAgain = extractKeyValue_(key, values_);
         // Retrieved the values again (values_) to prevent potential modifications 
         // by another thread between the findKey_ and the addKeyValue_ operations
         if(foundAgain) addKeyValue_(key, values_, false);
+        mlock.unlock();
+
     }
 
 #ifdef LOG_ASSOCIATIVE_CACHE

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -44,6 +44,7 @@ class DatabaseMTAssociativeCache
         inline bool enabled() const { return (log2IndexesSize > 0); };
         inline uint32_t getCacheSize()  const { return cacheSize; };
         inline uint32_t getIndexesSize() const { return indexesSize; };
+        inline uint32_t getAuxBufferKeysValuesSize() const { return auxBufferKeysValues.size(); };
         inline void clear(){
             if(enabled()){
                 postConstruct(log2IndexesSize, log2CacheSize, name);                
@@ -52,9 +53,9 @@ class DatabaseMTAssociativeCache
 
     private:
         inline bool emptyCacheSlot(uint32_t cacheIndexRaw) const { 
-            return (currentCacheIndex >= cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
+            return (currentCacheIndex > cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
             (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1 > cacheSize);
          };
-        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], int &iters);
+        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], int &iters, bool update);
 };
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -54,7 +54,7 @@ class DatabaseMTAssociativeCache
     private:
         inline bool emptyCacheSlot(uint32_t cacheIndexRaw) const { 
             return (currentCacheIndex > cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
-            (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1 > cacheSize);
+            (currentCacheIndex <= cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1 > cacheSize);
          };
         void forcedInsertion(uint32_t (&usedRawCacheIndexes)[20], int &iters, bool update);
 };

--- a/src/hashdb/database_cache.cpp
+++ b/src/hashdb/database_cache.cpp
@@ -244,6 +244,93 @@ void DatabaseMTCache::updateRecord(DatabaseCacheRecord* record, const void * val
     *(vector<Goldilocks::Element>*)(record->value) = *(vector<Goldilocks::Element>*)(value);
 }
 
+uint32_t DatabaseMTCache::fillCache(){
+
+    vector<Goldilocks::Element> value0(12);
+    value0[0].fe = 0;
+    vector<Goldilocks::Element> value1(12);
+    value1[0].fe = 0;
+
+    Goldilocks::Element key[4];
+    for (uint64_t i=0; i<maxSize/256; i++)
+    {
+        key[0].fe = i;
+        key[1].fe = i+1;
+        key[2].fe = i+2;
+        key[3].fe = i+3;
+        
+        string keyString = fea2string(fr,key); 
+        add(keyString,value0, false);
+        //get a random value from 0 to i
+        uint64_t random = rand() % (i+1);
+        key[0].fe = random;
+        key[1].fe = random+1;
+        key[2].fe = random+2;
+        key[3].fe = random+3;
+        find(fea2string(fr, key), value1);
+        value0[0]= value0[0]+value1[0];
+    }
+    return 1;
+
+}
+
+uint32_t DatabaseMTCache::fillCacheCahotic(){
+
+    vector<Goldilocks::Element> value0(12);
+    value0[0].fe = 0;
+    vector<Goldilocks::Element> value1(12);
+    value1[0].fe = 0;
+
+    uint32_t ndist = 1<<20;
+    uint32_t mask = ndist-1;
+    char ** memory_distorsion = (char**) malloc(ndist*sizeof(char*));
+    for (uint32_t i=0; i<ndist; i++)
+    {
+        memory_distorsion[i] = NULL;
+    }
+    uint32_t count = 0;
+    
+    Goldilocks::Element key[4];
+    for (uint64_t i=0; i<maxSize/256; i++)
+    {
+        key[0].fe = i;
+        key[1].fe = i+1;
+        key[2].fe = i+2;
+        key[3].fe = i+3;
+        
+        string keyString = fea2string(fr,key); 
+        add(keyString,value0, false);
+        //get a random value from 0 to i
+        uint64_t random = rand() % (i+1);
+        key[0].fe = random;
+        key[1].fe = random+1;
+        key[2].fe = random+2;
+        key[3].fe = random+3;
+        find(fea2string(fr, key), value1);
+        value0[0]= value0[0]+value1[0];
+        if(memory_distorsion[i & mask] != NULL)
+        {
+            free(memory_distorsion[i & mask]);
+        }
+        memory_distorsion[i & mask] = (char*) malloc((1<<20)*sizeof(char));
+        if(i%2==0) memory_distorsion[i & mask][3728] = 'a';
+    }
+    for(uint32_t i=0; i<ndist; i++)
+    {
+        if(memory_distorsion[i] != NULL)
+        {
+            if(memory_distorsion[i][3728] == 'a')
+            {
+                count++;
+            }
+            free(memory_distorsion[i]);
+        }
+    }
+    free(memory_distorsion);
+    return count;
+
+}
+
 // DatabaseProgramCache class implementation
 
 DatabaseProgramCache::~DatabaseProgramCache()

--- a/src/hashdb/database_cache.hpp
+++ b/src/hashdb/database_cache.hpp
@@ -67,6 +67,9 @@ public:
     DatabaseCacheRecord* allocRecord(const string key, const void * value) override;
     void freeRecord(DatabaseCacheRecord* record) override;
     void updateRecord(DatabaseCacheRecord* record, const void * value) override;
+    
+    uint32_t fillCache(); //fuctin only for benchmarkin purposes
+    uint32_t fillCacheCahotic(); //fuctin only for benchmarkin purposes
 };
 
 class DatabaseProgramCache : public DatabaseCache

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,6 +495,7 @@ int main(int argc, char **argv)
     if (config.runDatabaseCacheTest)
     {
         DatabaseCacheTest();
+        //DatabaseCacheBenchmark();
     }
 
     // Test check tree

--- a/test/hashdb/database_cache_test.cpp
+++ b/test/hashdb/database_cache_test.cpp
@@ -51,5 +51,222 @@ uint64_t DatabaseCacheTest (void)
     Database::dbMTCache.clear();
 
     TimerStopAndLog(DATABASE_CACHE_TEST);
+
+    TimerStart(DATABASE_ASSOCIATIVE_CACHE_TEST);
+
+    DatabaseMTAssociativeCache cache1(20, 17, "cache1");
+    uint64_t NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS = cache1.getCacheSize();
+    //test addKeyValue addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
+
+    //generate a set of random keys
+    PoseidonGoldilocks poseidon_test;
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> InputValue;
+        for(int k=0; k<12; ++k){
+            InputValue.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(InputValue.data()[0]));
+        cache1.addKeyValue(key, InputValue, false);
+    }
+    //test findKey
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        value.clear();
+        bResult = cache1.findKey(key, value);
+        //check the value is found
+        if (!bResult)
+        {
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+        //check the value is correct
+        for(int k=0; k<12; ++k){
+            if(value[k].fe != fr.fromU64(i).fe){
+                zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+                numberOfFailed++;
+            }
+        }
+
+    }
+    // test update
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        // modify the value
+        for(int k=0; k<12; ++k){
+            value[k] = fr.fromU64(i+1);
+        }
+        cache1.addKeyValue(key, value, true);
+    }
+    //test findKey with updated values
+     for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        value.clear();
+        bResult = cache1.findKey(key, value);
+        //check the value is found
+        if (!bResult)
+        {
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+        //check the value is correct
+        for(int k=0; k<12; ++k){
+            if(value[k].fe != fr.fromU64(i+1).fe){
+                zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+                numberOfFailed++;
+            }
+        }
+
+    }
+    //test clear: clear the cache and check I do not find previous keys
+    cache1.clear();
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        bResult = cache1.findKey(key, value);
+        //check the value is found
+        if (bResult)
+        {
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+    //collisions and auxBufferKeysValues
+    Goldilocks::Element key1[4];
+    Goldilocks::Element key2[4];
+    Goldilocks::Element key3[4];
+    key1[0] = fr.fromU64(0);
+    key1[1] = fr.fromU64(0);
+    key1[2] = fr.fromU64(0);
+    key1[3] = fr.fromU64(0);
+
+    key2[0] = fr.fromU64(uint64_t(1)<<50);
+    key2[1] = fr.fromU64(0);
+    key2[2] = fr.fromU64(0);
+    key2[3] = fr.fromU64(0);
+    
+    key3[0] = fr.fromU64(0);
+    key3[1] = fr.fromU64(uint64_t(1)<<44);
+    key3[2] = fr.fromU64(0);
+    key3[3] = fr.fromU64(0);
+    
+    // Key 0 and Key 1 have only one position availe in the indexes table, if I add both the buffer auxBufferKeysValues should be used
+    vector<Goldilocks::Element> value1(12);
+    vector<Goldilocks::Element> value2(12);
+    vector<Goldilocks::Element> value3(12);
+    for(int k=0; k<12; ++k){
+        value1[k] = fr.fromU64(1);
+        value2[k] = fr.fromU64(2);
+        value3[k] = fr.fromU64(3);
+    }
+    cache1.addKeyValue(key1, value1, false);
+    if(cache1.getAuxBufferKeysValuesSize()!=0){
+        zklog.error("DatabaseCacheTest() failed calling cache1.getAuxBufferKeysValuesSize()");
+        numberOfFailed++;
+    }
+    cache1.addKeyValue(key2, value2, false);
+    if(cache1.getAuxBufferKeysValuesSize()!=17){
+        zklog.error("DatabaseCacheTest() failed calling cache1.getAuxBufferKeysValuesSize()");
+        numberOfFailed++;
+    }
+    cache1.addKeyValue(key3, value3, false);
+    if(cache1.getAuxBufferKeysValuesSize()!=34){
+        zklog.error("DatabaseCacheTest() failed calling cache1.getAuxBufferKeysValuesSize()");
+        numberOfFailed++;
+    }
+    
+    //check the values are correct
+    vector<Goldilocks::Element> value1_;
+    bResult = cache1.findKey(key1, value1_);
+    if (!bResult)
+    {
+        zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+        numberOfFailed++;
+    }
+    for(int k=0; k<12; ++k){
+        if(value1_[k].fe != value1[k].fe){
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+    
+    vector<Goldilocks::Element> value2_;
+    bResult = cache1.findKey(key2, value2_);
+    if (!bResult)
+    {
+        zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+        numberOfFailed++;
+    }
+    for(int k=0; k<12; ++k){
+        if(value2_[k].fe != value2[k].fe){
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+    
+    vector<Goldilocks::Element> value3_;
+    bResult = cache1.findKey(key3, value3_);
+    if (!bResult)
+    {
+        zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+        numberOfFailed++;
+    }
+    for(int k=0; k<12; ++k){
+        if(value3_[k].fe != value3[k].fe){
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+
+    //check that after doing a round to the cache the elements are not anymore into de auxBufferKeysValues
+    for (uint64_t i=0; i<cache1.getCacheSize()-2; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        // modify the value
+        for(int k=0; k<12; ++k){
+            value[k] = fr.fromU64(i+1);
+        }
+        cache1.addKeyValue(key, value, true);
+        if(cache1.getAuxBufferKeysValuesSize()==0){
+            zklog.error("DatabaseCacheTest() auxBufferKeysValues should not be cleaned");
+            numberOfFailed++;
+        }
+    }
+    /*if(cache1.getAuxBufferKeysValuesSize()!=0){
+        zklog.error("DatabaseCacheTest() failed the cleaning of auxBufferKeysValues");
+        numberOfFailed++;
+    }*/
+
+    TimerStopAndLog(DATABASE_ASSOCIATIVE_CACHE_TEST);
+    assert(numberOfFailed == 0);
     return numberOfFailed;
 }

--- a/test/hashdb/database_cache_test.cpp
+++ b/test/hashdb/database_cache_test.cpp
@@ -82,17 +82,18 @@ uint64_t DatabaseCacheTest (void)
         poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
         value.clear();
         bResult = cache1.findKey(key, value);
-        //check the value is found
         if (!bResult)
         {
             zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
             numberOfFailed++;
         }
-        //check the value is correct
-        for(int k=0; k<12; ++k){
-            if(value[k].fe != fr.fromU64(i).fe){
-                zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
-                numberOfFailed++;
+        if(bResult){
+            //check the value is correct
+            for(int k=0; k<12; ++k){
+                if(value[k].fe != fr.fromU64(i).fe){
+                    zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+                    numberOfFailed++;
+                }
             }
         }
 
@@ -244,7 +245,7 @@ uint64_t DatabaseCacheTest (void)
     }
 
     //check that after doing a round to the cache the elements are not anymore into de auxBufferKeysValues
-    for (uint64_t i=0; i<cache1.getCacheSize()-2; i++)
+    for (uint64_t i=0; i<2*cache1.getCacheSize(); i++)
     {
         Goldilocks::Element key[4];
         vector<Goldilocks::Element> value;
@@ -257,16 +258,16 @@ uint64_t DatabaseCacheTest (void)
             value[k] = fr.fromU64(i+1);
         }
         cache1.addKeyValue(key, value, true);
-        if(cache1.getAuxBufferKeysValuesSize()==0){
-            zklog.error("DatabaseCacheTest() auxBufferKeysValues should not be cleaned");
+        if(cache1.getAuxBufferKeysValuesSize()==0 && i<cache1.getCacheSize()-2){
+            zklog.error("DatabaseCacheTest() auxBufferKeysValues should not be cleaned" + to_string(cache1.getAuxBufferKeysValuesSize()));
             numberOfFailed++;
         }
     }
-    /*if(cache1.getAuxBufferKeysValuesSize()!=0){
-        zklog.error("DatabaseCacheTest() failed the cleaning of auxBufferKeysValues");
+    
+    if(cache1.getAuxBufferKeysValuesSize()!=0){
+        zklog.error("DatabaseCacheTest() failed the cleaning of auxBufferKeysValues"+ to_string(cache1.getAuxBufferKeysValuesSize()));
         numberOfFailed++;
-    }*/
-
+    }
     TimerStopAndLog(DATABASE_ASSOCIATIVE_CACHE_TEST);
     assert(numberOfFailed == 0);
     return numberOfFailed;

--- a/test/hashdb/database_cache_test.hpp
+++ b/test/hashdb/database_cache_test.hpp
@@ -4,5 +4,6 @@
 #include <cstdint>
 
 uint64_t DatabaseCacheTest (void);
+uint64_t DatabaseCacheBenchmark (void);
 
 #endif


### PR DESCRIPTION
This PR extends the capability of previous implementation of associative cache. 

Basically, considers the edge case in which a key can not be included into the cache .  For each key, 4 possible locations into the associative cache are considered, if these 4 slots are already in use, an iterative process is started in which we try to reallocate the "collisioning" keys.  Chances to not fins a slot during this iterative process are almost negligible however, for the sake of safety we have added a buffer to temporally allocate entries which could not be included with the "normal" process, this buffer is used only temporarily and is cleaned automatically. 

Unity test have been added to test the functioning of the extension buffer. 

Other minor changes have been added which do not affect the previous functioning of the associative cache. 