### PR TITLE
Release v6.0.0 associative cache

### DIFF
--- a/src/config/definitions.hpp
+++ b/src/config/definitions.hpp
@@ -61,6 +61,7 @@
 #define LOG_FULL_TRACER_ON_ERROR
 //#define LOG_TX_HASH
 //#define LOG_INPUT
+//#define LOG_ASSOCIATIVE_CACHE
 //LOG_SMT_KEY_DETAILS
 
 /* Prover defines */

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -211,11 +211,11 @@ bool DatabaseMTAssociativeCache::extractKeyValue_(const Goldilocks::Element (&ke
                 value[9] = values[cacheIndexValue + 9];
                 value[10] = values[cacheIndexValue + 10];
                 value[11] = values[cacheIndexValue + 11]; 
-                found=true;  
+                return true;  
             }
         }
     }
-    return found;
+    return false;
 }
 
 bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
@@ -224,6 +224,9 @@ bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks:
     // for this reason this search is not optimized at all
     //
     if(auxBufferKeysValues.size() > 0){ 
+        if(auxBufferKeysValues.size() % 17!= 0) {
+            zklog.error("DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() auxBufferKeysValues.size() % 17!= 0");
+        }
         for(size_t i=0; i<auxBufferKeysValues.size(); i+=17){
 
             if( !hasExpired_(((uint32_t)(auxBufferKeysValues[i].fe))) &&
@@ -257,7 +260,11 @@ void DatabaseMTAssociativeCache::addKeyValue_(const Goldilocks::Element (&key)[4
 {
     if(auxBufferKeysValues.size() > 0){
         vector<Goldilocks::Element> value_;
-        extractKeyValueFromAuxBuffer_(key,value_);
+        bool found = extractKeyValueFromAuxBuffer_(key,value_);
+        if(update == false && found){
+            addKeyValue_(key, value_, false);
+            return;
+        }
     }
     bool emptySlot = false;
     bool present = false;

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -86,6 +86,9 @@ void DatabaseMTAssociativeCache::postConstruct(uint32_t log2IndexesSize_, uint32
 
     if(indexes == NULL){
         indexes = new uint32_t[indexesSize];
+    }else{
+        delete[] indexes;
+        indexes = new uint32_t[indexesSize];
     }
     // initialization of indexes array with UINT32_MAX-cacheSize: the value
     // that is at distance cacheSize+1 from the initial currentCacheIndex, i.e. 0
@@ -97,14 +100,23 @@ void DatabaseMTAssociativeCache::postConstruct(uint32_t log2IndexesSize_, uint32
     }
     if(keys == NULL){
         keys = new Goldilocks::Element[4 * cacheSize];
+    }else{
+        delete[] keys;
+        keys = new Goldilocks::Element[4 * cacheSize];
     }
 
     if(isValidKey == NULL){
+        isValidKey = new bool[cacheSize];
+    }else{
+        delete[] isValidKey;
         isValidKey = new bool[cacheSize];
     }
     memset(isValidKey, 0, cacheSize * sizeof(bool));
 
     if(values == NULL){ 
+        values = new Goldilocks::Element[12 * cacheSize];
+    }else{
+        delete[] values;
         values = new Goldilocks::Element[12 * cacheSize];
     }
 

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -7,9 +7,7 @@
 #include "zkmax.hpp"
 #include "exit_process.hpp"
 #include "scalar.hpp"
-
-
-
+#include "zkassert.hpp"
 
 DatabaseMTAssociativeCache::DatabaseMTAssociativeCache()
 {
@@ -20,16 +18,44 @@ DatabaseMTAssociativeCache::DatabaseMTAssociativeCache()
     indexes = NULL;
     keys = NULL;
     values = NULL;
+    isValidKey = NULL;
     currentCacheIndex = 0;
+#ifdef LOG_ASSOCIATIVE_CACHE
     attempts = 0;
     hits = 0;
+#endif
     name = "";
+    auxBufferKeysValues.clear();
 };
 
-DatabaseMTAssociativeCache::DatabaseMTAssociativeCache(int log2IndexesSize_, int cacheSize_, string name_)
+DatabaseMTAssociativeCache::DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_) :
+    indexes(NULL), keys(NULL), isValidKey(NULL), values(NULL), currentCacheIndex(0), name(name_)
 {
-    postConstruct(log2IndexesSize_, cacheSize_, name_);
+    postConstruct(log2IndexesSize_, log2CacheSize_, name_);
 };
+DatabaseMTAssociativeCache::DatabaseMTAssociativeCache(uint64_t cacheBytes_,string name_) :
+indexes(NULL), keys(NULL), isValidKey(NULL), values(NULL), currentCacheIndex(0), name(name_)
+{
+
+    // Each cache entrie requires 16 Goldiclosk::Elements, 4 for the key and 12 for the value
+    // This is 16*8 = 128 bytes
+    uint32_t log2IndexesSize_ = 0;
+    uint32_t log2CacheSize_ = 0;
+    for(uint64_t i=28; i>=1; --i){
+        uint64_t bytes = uint64_t(1<<i)*uint64_t(128)+uint64_t(1<<(i+3))*uint64_t(4);
+        if(bytes <= cacheBytes_){
+
+            int cacheMB = cacheBytes_/1024/1024;
+            int usedMB = bytes/1024/1024;
+            zklog.info( to_string(usedMB) + " MB of " + to_string(cacheMB) + " MB used for " + name_ + " associative cache. " + to_string(2*usedMB) + " MB should be exposed to efectively increase the cache size.");
+            log2IndexesSize_ = i+3;
+            log2CacheSize_ = i;
+            break;
+        }
+    }
+
+    postConstruct(log2IndexesSize_, log2CacheSize_, name_);
+}
 
 DatabaseMTAssociativeCache::~DatabaseMTAssociativeCache()
 {
@@ -39,94 +65,231 @@ DatabaseMTAssociativeCache::~DatabaseMTAssociativeCache()
         delete[] keys;
     if (values != NULL)
         delete[] values;
+    if(isValidKey != NULL)
+        delete[] isValidKey;
+    auxBufferKeysValues.clear();
 
 };
 
-void DatabaseMTAssociativeCache::postConstruct(int log2IndexesSize_, int log2CacheSize_, string name_)
+void DatabaseMTAssociativeCache::postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_)
 {
-    lock_guard<recursive_mutex> guard(mlock);
+    unique_lock<shared_mutex> guard(mlock);
     log2IndexesSize = log2IndexesSize_;
-    if (log2IndexesSize_ > 32)
+    if (log2IndexesSize_ > 31)
     {
-        zklog.error("DatabaseMTAssociativeCache::DatabaseMTAssociativeCache() log2IndexesSize_ > 32");
+        // if log2IndexesSize_ >=32, we would need to use uint64_t values to refere to positions in the indexes array
+        zklog.error("DatabaseMTAssociativeCache::DatabaseMTAssociativeCache() log2IndexesSize_ > 31");
         exitProcess();
     }
     indexesSize = 1 << log2IndexesSize;
 
     log2CacheSize = log2CacheSize_;
-    if (log2CacheSize_ > 32)
+    if (log2CacheSize_ > 28)
     {
-        zklog.error("DatabaseMTAssociativeCache::DatabaseMTAssociativeCache() log2CacheSize_ > 32");
+        // if log2CacheSize_ > 28, we would need to use uint64_t values to refere to positions in the keys and values arrays
+        // note thar for each cacheIndex we have 4 keys and 12 values
+        zklog.error("DatabaseMTAssociativeCache::DatabaseMTAssociativeCache() log2CacheSize_ > 31");
         exitProcess();
     }
-    cacheSize = 1 << log2CacheSize_;
+    cacheSize = 1 << log2CacheSize;
+    cacheSizeDiv2 = cacheSize / 2;
 
-    if(indexes != NULL) delete[] indexes;
-    indexes = new uint32_t[indexesSize];
-    //initialization of indexes array
-    uint32_t initValue = UINT32_MAX-cacheSize-(uint32_t)1;
+    if ( indexesSize / cacheSize < 8)
+    {
+        // This forces that the maximum occupancy of the table of indexes is 12.5%
+        zklog.error("DatabaseMTAssociativeCache::DatabaseMTAssociativeCache() indexesSize/ cacheSize < 8");
+        exitProcess();
+    }
+
+    if(indexes == NULL){
+        indexes = new uint32_t[indexesSize];
+    }
+    // initialization of indexes array with UINT32_MAX-cacheSize: the value
+    // that is at distance cacheSize+1 from the initial currentCacheIndex, i.e. 0
+    uint32_t initValue = UINT32_MAX-cacheSize;
     #pragma omp parallel for schedule(static) num_threads(4)
     for (size_t i = 0; i < indexesSize; i++)
     {
         indexes[i] = initValue;
     }
-    if(keys != NULL) delete[] keys;
-    keys = new Goldilocks::Element[4 * cacheSize];
+    if(keys == NULL){
+        keys = new Goldilocks::Element[4 * cacheSize];
+    }
 
-    if(values != NULL) delete[] values;
-    values = new Goldilocks::Element[12 * cacheSize];
+    if(isValidKey == NULL){
+        isValidKey = new bool[cacheSize];
+    }
+    memset(isValidKey, 0, cacheSize * sizeof(bool));
+
+    if(values == NULL){ 
+        values = new Goldilocks::Element[12 * cacheSize];
+    }
 
     currentCacheIndex = 0;
+#ifdef LOG_ASSOCIATIVE_CACHE
     attempts = 0;
     hits = 0;
+#endif
     name = name_;
     
     //masks for fast module, note cache size and indexes size must be power of 2
     cacheMask = cacheSize - 1;
     indexesMask = indexesSize - 1;
+
+    auxBufferKeysValues.clear();
+
 };
 
-void DatabaseMTAssociativeCache::addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update)
+void DatabaseMTAssociativeCache::clear(){
+    unique_lock<shared_mutex> guard(mlock);
+    memset(isValidKey, 0, cacheSize * sizeof(bool));
+    uint32_t initValue = UINT32_MAX-cacheSize;
+    #pragma omp parallel for schedule(static) num_threads(4)
+    for (size_t i = 0; i < indexesSize; i++)
+    {
+        indexes[i] = initValue;
+    }
+    auxBufferKeysValues.clear();
+    currentCacheIndex = 0;
+}
+
+bool DatabaseMTAssociativeCache::extractKeyValue_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value)
 {
-    lock_guard<recursive_mutex> guard(mlock);
+    bool found = false;    
+    //
+    // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
+    // for this reason this search is not optimized at all
+    //
+    if(auxBufferKeysValues.size() > 0){ 
+        found = extractKeyValueFromAuxBuffer_(key,value);
+    }
+    //
+    // Look at the circulant buffer
+    //
+    if(found == false){
+        for (int i = 0; i < 4; i++)
+        {
+            uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
+            if (hasExpired_(cacheIndexRaw)) continue;
+            
+            uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
+            uint32_t cacheIndexKey = cacheIndex * 4;
+            if (keys[cacheIndexKey + 0].fe == key[0].fe &&
+                keys[cacheIndexKey + 1].fe == key[1].fe &&
+                keys[cacheIndexKey + 2].fe == key[2].fe &&
+                keys[cacheIndexKey + 3].fe == key[3].fe)
+            {
+                isValidKey[cacheIndexRaw & cacheMask]=false;
+                uint32_t cacheIndexValue = cacheIndex * 12;
+                value.resize(12);
+                value[0] = values[cacheIndexValue];
+                value[1] = values[cacheIndexValue + 1];
+                value[2] = values[cacheIndexValue + 2];
+                value[3] = values[cacheIndexValue + 3];
+                value[4] = values[cacheIndexValue + 4];
+                value[5] = values[cacheIndexValue + 5];
+                value[6] = values[cacheIndexValue + 6];
+                value[7] = values[cacheIndexValue + 7];
+                value[8] = values[cacheIndexValue + 8];
+                value[9] = values[cacheIndexValue + 9];
+                value[10] = values[cacheIndexValue + 10];
+                value[11] = values[cacheIndexValue + 11]; 
+                found=true;  
+            }
+        }
+    }
+    return found;
+}
+
+bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
+    bool found = false;    
+    //
+    // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
+    // for this reason this search is not optimized at all
+    //
+    if(auxBufferKeysValues.size() > 0){ 
+        for(size_t i=0; i<auxBufferKeysValues.size(); i+=17){
+
+            if( !hasExpired_(((uint32_t)(auxBufferKeysValues[i].fe))) &&
+                auxBufferKeysValues[i+1].fe == key[0].fe &&
+                auxBufferKeysValues[i+2].fe == key[1].fe &&
+                auxBufferKeysValues[i+3].fe == key[2].fe &&
+                auxBufferKeysValues[i+4].fe == key[3].fe){
+                value.resize(12);
+                value[0] = auxBufferKeysValues[i+5];
+                value[1] = auxBufferKeysValues[i+6];
+                value[2] = auxBufferKeysValues[i+7];
+                value[3] = auxBufferKeysValues[i+8];
+                value[4] = auxBufferKeysValues[i+9];
+                value[5] = auxBufferKeysValues[i+10];
+                value[6] = auxBufferKeysValues[i+11];
+                value[7] = auxBufferKeysValues[i+12];
+                value[8] = auxBufferKeysValues[i+13];
+                value[9] = auxBufferKeysValues[i+14];
+                value[10] = auxBufferKeysValues[i+15];
+                value[11] = auxBufferKeysValues[i+16];
+                //erase the value
+                auxBufferKeysValues.erase(auxBufferKeysValues.begin() + i, auxBufferKeysValues.begin() + i + 17);   
+                found=true;
+            }
+        } 
+    }
+    return found;
+}
+
+void DatabaseMTAssociativeCache::addKeyValue_(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update)
+{
+    if(auxBufferKeysValues.size() > 0){
+        vector<Goldilocks::Element> value_;
+        extractKeyValueFromAuxBuffer_(key,value_);
+    }
     bool emptySlot = false;
     bool present = false;
     uint32_t cacheIndex;
     uint32_t tableIndexEmpty=0;
 
     //
-    // Check if present in one of the four slots
+    // Check if present in one of the four slots or there is an empty slot
     //
     for (int i = 0; i < 4; ++i)
     {
-        uint32_t tableIndex = (uint32_t)(key[i].fe & indexesMask);
+        uint32_t tableIndex = key[i].fe & indexesMask;
         uint32_t cacheIndexRaw = indexes[tableIndex];
-        cacheIndex = cacheIndexRaw & cacheMask;
-        uint32_t cacheIndexKey = cacheIndex * 4;
 
-        if (!emptyCacheSlot(cacheIndexRaw)){
+        if (!hasExpired_(cacheIndexRaw)){
+            cacheIndex = cacheIndexRaw & cacheMask;
+            uint32_t cacheIndexKey = cacheIndex * 4;
             if( keys[cacheIndexKey + 0].fe == key[0].fe &&
                 keys[cacheIndexKey + 1].fe == key[1].fe &&
                 keys[cacheIndexKey + 2].fe == key[2].fe &&
                 keys[cacheIndexKey + 3].fe == key[3].fe){
-                    if(update == false) return;
-                    present = true;
-                    break;
+                    if(distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSizeDiv2){
+                        //
+                        // It is present but it is far from the currentCacheIndex, so we need to reinsert it
+                        //
+                        vector<Goldilocks::Element> value_;
+                        extractKeyValue_(key,value_);
+                    }else{
+                        if(update == false) return;
+                        present = true;
+                        break;
+                    }
             }
         }else if (emptySlot == false){
             emptySlot = true;
             tableIndexEmpty = tableIndex;
+            // I can not break because I need to check if the key is present in the other slots
         }
     }
 
     //
-    // Evaluate cacheIndexKey and 
+    // Evaluate cacheIndexKey 
     //
     if(!present){
         if(emptySlot == true){
             indexes[tableIndexEmpty] = currentCacheIndex;
         }
-        cacheIndex = (uint32_t)(currentCacheIndex & cacheMask);
+        cacheIndex = currentCacheIndex & cacheMask;
         currentCacheIndex = (currentCacheIndex == UINT32_MAX) ? 0 : (currentCacheIndex + 1);
     }
     uint64_t cacheIndexKey, cacheIndexValue;
@@ -136,10 +299,12 @@ void DatabaseMTAssociativeCache::addKeyValue(Goldilocks::Element (&key)[4], cons
     //
     // Add value
     //
+    isValidKey[cacheIndex] = true;
     keys[cacheIndexKey + 0].fe = key[0].fe;
     keys[cacheIndexKey + 1].fe = key[1].fe;
     keys[cacheIndexKey + 2].fe = key[2].fe;
     keys[cacheIndexKey + 3].fe = key[3].fe;
+    zkassert(value.size() == 12 || value.size() == 8);
     values[cacheIndexValue + 0] = value[0];
     values[cacheIndexValue + 1] = value[1];
     values[cacheIndexValue + 2] = value[2];
@@ -149,7 +314,7 @@ void DatabaseMTAssociativeCache::addKeyValue(Goldilocks::Element (&key)[4], cons
     values[cacheIndexValue + 6] = value[6];
     values[cacheIndexValue + 7] = value[7];
     if (value.size() > 8)
-    {
+    {   
         values[cacheIndexValue + 8] = value[8];
         values[cacheIndexValue + 9] = value[9];
         values[cacheIndexValue + 10] = value[10];
@@ -165,37 +330,41 @@ void DatabaseMTAssociativeCache::addKeyValue(Goldilocks::Element (&key)[4], cons
     // Forced index insertion
     //
     if(!present && !emptySlot){
-        int iters = 0;
-        uint32_t usedRawCacheIndexes[10];
-        usedRawCacheIndexes[0] = currentCacheIndex-1;
-        forcedInsertion(usedRawCacheIndexes, iters);
+        uint32_t iter = 0;
+        uint32_t usedRawCacheIndexes[20]; // we will do at maximum 20 iterations
+        usedRawCacheIndexes[0] = (currentCacheIndex == 0) ? UINT32_MAX : currentCacheIndex-1;
+        forcedInsertion_(usedRawCacheIndexes, iter, update);
+    }
+    //
+    // Clear empty auxBufferKeysValues slots (the probability of auxBufferKeysValues.size() > 0 is almost negligible)
+    //
+    if(auxBufferKeysValues.size() > 0){
+        cleanExpiredAuxBufferKeysValues_();
     }
 }
 
-void DatabaseMTAssociativeCache::forcedInsertion(uint32_t (&usedRawCacheIndexes)[10], int &iters)
+// This function is called recursively a maximum of 20 times. The probability of not finding a free slot at
+// each call is multiplied by roughly 1/2**9 (three new keys are checks and I assume the ratio cacheSize/indexesSize 
+// is 1/8). With this rough estimation the probablilty of requiring 20 iterations would be 1/2**180. If, after 20 
+// iterations is not possible to find a free slot, the entry is added to the auxBufferKeysValues vector.
+void DatabaseMTAssociativeCache::forcedInsertion_(uint32_t (&usedRawCacheIndexes)[20], uint32_t &iters, bool update)
 {
     uint32_t inputRawCacheIndex = usedRawCacheIndexes[iters];
-    //
-    // avoid infinite loop
-    //
     iters++;
-    if (iters > 9)
-    {
-        zklog.error("forcedInsertion() more than 10 iterations required. Index: " + to_string(inputRawCacheIndex));
-        exitProcess();
-    }    
+
     //
     // find a slot into my indexes
     //
     Goldilocks::Element *inputKey = &keys[(inputRawCacheIndex & cacheMask) * 4];
+
     uint32_t minRawCacheIndex = UINT32_MAX;
     int pos = -1;
 
     for (int i = 0; i < 4; ++i)
     {
-        uint32_t tableIndex_ = (uint32_t)(inputKey[i].fe & indexesMask);
-        uint32_t rawCacheIndex_ = (uint32_t)(indexes[tableIndex_]);
-        if (emptyCacheSlot(rawCacheIndex_))
+        uint32_t tableIndex_ = inputKey[i].fe & indexesMask;
+        uint32_t rawCacheIndex_ = indexes[tableIndex_];
+        if (hasExpired_(rawCacheIndex_))
         {
             indexes[tableIndex_] = inputRawCacheIndex;
             return;
@@ -204,75 +373,168 @@ void DatabaseMTAssociativeCache::forcedInsertion(uint32_t (&usedRawCacheIndexes)
         {
             //consider minimum not used rawCacheIndex_
             bool used = false;
-            for(int k=0; k<iters; k++){
+            for(uint32_t k=0; k<iters; k++){
+                // remember that with vergy high probability iters < 3
                 if(usedRawCacheIndexes[k] == rawCacheIndex_){
                     used = true;
                     break;
                 }
             }
-            if (!used && rawCacheIndex_ < minRawCacheIndex)
+            if (!used && rawCacheIndex_ <= minRawCacheIndex)
             {
                 minRawCacheIndex = rawCacheIndex_;
                 pos = i;
             }
         }
     }
-
-    if (pos < 0)
-    {
-        zklog.error("forcedInsertion() could not continue the recursion: " + to_string(inputRawCacheIndex));
-        exitProcess();
-    } 
-    indexes[(uint32_t)(inputKey[pos].fe & indexesMask)] = inputRawCacheIndex;
-    usedRawCacheIndexes[iters] = minRawCacheIndex; //new cache element to add in the indexes table
-    forcedInsertion(usedRawCacheIndexes, iters);
     
+    //
+    // avoid infinite loop, only 20 iterations allowed, pox < 0 means that there is no unused slot to continue iterating
+    //
+    if (iters >=20 || pos == -1)
+    {
+        zklog.warning("forcedInsertion_() maxforcedInsertion_Iterations reached");
+        Goldilocks::Element *buffKey = &keys[(inputRawCacheIndex & cacheMask) * 4];
+        Goldilocks::Element *buffValue = &values[(inputRawCacheIndex & cacheMask) * 12];
+        
+        // check first if there is an slot in the vector where the key is already present
+        int pos = -1;
+        for(size_t i=0; i<auxBufferKeysValues.size(); i+=17){
+            if( hasExpired_(((uint32_t)(auxBufferKeysValues[i].fe)))){
+                if(pos < 0) pos = i;
+            }else{
+                if( auxBufferKeysValues[i+1].fe == buffKey[0].fe &&
+                    auxBufferKeysValues[i+2].fe == buffKey[1].fe &&
+                    auxBufferKeysValues[i+3].fe == buffKey[2].fe &&
+                    auxBufferKeysValues[i+4].fe == buffKey[3].fe){
+                    if(update == false) return;
+                    pos = i;
+                }
+            }
+        }
+        if(pos != -1){
+            auxBufferKeysValues[pos] = Goldilocks::fromU64((uint64_t)(inputRawCacheIndex));
+            auxBufferKeysValues[pos + 1] = buffKey[0];
+            auxBufferKeysValues[pos + 2] = buffKey[1];
+            auxBufferKeysValues[pos + 3] = buffKey[2];
+            auxBufferKeysValues[pos + 4] = buffKey[3];    
+            auxBufferKeysValues[pos + 5] = buffValue[0];
+            auxBufferKeysValues[pos + 6] = buffValue[1];
+            auxBufferKeysValues[pos + 7] = buffValue[2];
+            auxBufferKeysValues[pos + 8] = buffValue[3];
+            auxBufferKeysValues[pos + 9] = buffValue[4];
+            auxBufferKeysValues[pos + 10] = buffValue[5];
+            auxBufferKeysValues[pos + 11] = buffValue[6];
+            auxBufferKeysValues[pos + 12] = buffValue[7];
+            auxBufferKeysValues[pos + 13] = buffValue[8];
+            auxBufferKeysValues[pos + 14] = buffValue[9];
+            auxBufferKeysValues[pos + 15] = buffValue[10];
+            auxBufferKeysValues[pos + 16] = buffValue[11];
+
+        }else{
+            auxBufferKeysValues.push_back(Goldilocks::fromU64((uint64_t)(inputRawCacheIndex)));
+            auxBufferKeysValues.push_back(buffKey[0]);
+            auxBufferKeysValues.push_back(buffKey[1]);
+            auxBufferKeysValues.push_back(buffKey[2]);
+            auxBufferKeysValues.push_back(buffKey[3]);
+            auxBufferKeysValues.push_back(buffValue[0]);
+            auxBufferKeysValues.push_back(buffValue[1]);
+            auxBufferKeysValues.push_back(buffValue[2]);
+            auxBufferKeysValues.push_back(buffValue[3]);
+            auxBufferKeysValues.push_back(buffValue[4]);
+            auxBufferKeysValues.push_back(buffValue[5]);
+            auxBufferKeysValues.push_back(buffValue[6]);
+            auxBufferKeysValues.push_back(buffValue[7]);
+            auxBufferKeysValues.push_back(buffValue[8]);
+            auxBufferKeysValues.push_back(buffValue[9]);
+            auxBufferKeysValues.push_back(buffValue[10]);
+            auxBufferKeysValues.push_back(buffValue[11]);
+        }
+        return;
+    }else{
+        indexes[(uint32_t)(inputKey[pos].fe & indexesMask)] = inputRawCacheIndex;
+        usedRawCacheIndexes[iters] = minRawCacheIndex; //new cache element to add in the indexes table
+        forcedInsertion_(usedRawCacheIndexes, iters, update);
+    }
 }
 
-bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value)
+bool DatabaseMTAssociativeCache::findKey_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value, bool &reinsert)
 {
-    lock_guard<recursive_mutex> guard(mlock);
-    attempts++; 
+    bool found = false;
+    reinsert = false;
     //
-    //  Statistics
+    // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
+    // for this reason this search is not optimized at all
     //
-    if (attempts<<40 == 0)
-    {
-        zklog.info("DatabaseMTAssociativeCache::findKey() name=" + name + " indexesSize=" + to_string(indexesSize) + " cacheSize=" + to_string(cacheSize) + " attempts=" + to_string(attempts) + " hits=" + to_string(hits) + " hit ratio=" + to_string(double(hits) * 100.0 / double(zkmax(attempts, 1))) + "%");
+    if(auxBufferKeysValues.size() > 0){ 
+        if(auxBufferKeysValues.size() % 17!= 0) {
+            zklog.error("DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() auxBufferKeysValues.size() % 17!= 0");
+        }
+        for(size_t i=0; i<auxBufferKeysValues.size(); i+=17){
+            
+            if( !hasExpired_(((uint32_t)(auxBufferKeysValues[i].fe))) &&
+                auxBufferKeysValues[i+1].fe == key[0].fe &&
+                auxBufferKeysValues[i+2].fe == key[1].fe &&
+                auxBufferKeysValues[i+3].fe == key[2].fe &&
+                auxBufferKeysValues[i+4].fe == key[3].fe){
+                value.resize(12);
+                value[0] = auxBufferKeysValues[i+5];
+                value[1] = auxBufferKeysValues[i+6];
+                value[2] = auxBufferKeysValues[i+7];
+                value[3] = auxBufferKeysValues[i+8];
+                value[4] = auxBufferKeysValues[i+9];
+                value[5] = auxBufferKeysValues[i+10];
+                value[6] = auxBufferKeysValues[i+11];
+                value[7] = auxBufferKeysValues[i+12];
+                value[8] = auxBufferKeysValues[i+13];
+                value[9] = auxBufferKeysValues[i+14];
+                value[10] = auxBufferKeysValues[i+15];
+                value[11] = auxBufferKeysValues[i+16];
+                found=true;
+                if(distanceFromCurrentCacheIndex_((uint32_t)(auxBufferKeysValues[i].fe)) > cacheSizeDiv2){
+                    reinsert = true;
+                }
+                break;
+            }
+        } 
     }
     //
-    // Find the value
+    // Look at the circulant buffer
     //
-    for (int i = 0; i < 4; i++)
-    {
-        uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
-        if (emptyCacheSlot(cacheIndexRaw)) continue;
-        
-        uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
-        uint32_t cacheIndexKey = cacheIndex * 4;
-
-        if (keys[cacheIndexKey + 0].fe == key[0].fe &&
-            keys[cacheIndexKey + 1].fe == key[1].fe &&
-            keys[cacheIndexKey + 2].fe == key[2].fe &&
-            keys[cacheIndexKey + 3].fe == key[3].fe)
+    if(!found){
+        for (int i = 0; i < 4; i++)
         {
-            uint32_t cacheIndexValue = cacheIndex * 12;
-            ++hits;
-            value.resize(12);
-            value[0] = values[cacheIndexValue];
-            value[1] = values[cacheIndexValue + 1];
-            value[2] = values[cacheIndexValue + 2];
-            value[3] = values[cacheIndexValue + 3];
-            value[4] = values[cacheIndexValue + 4];
-            value[5] = values[cacheIndexValue + 5];
-            value[6] = values[cacheIndexValue + 6];
-            value[7] = values[cacheIndexValue + 7];
-            value[8] = values[cacheIndexValue + 8];
-            value[9] = values[cacheIndexValue + 9];
-            value[10] = values[cacheIndexValue + 10];
-            value[11] = values[cacheIndexValue + 11];
-            return true;
+            uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
+            if (hasExpired_(cacheIndexRaw)) continue;
+            
+            uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
+            uint32_t cacheIndexKey = cacheIndex * 4;
+
+            if (keys[cacheIndexKey + 0].fe == key[0].fe &&
+                keys[cacheIndexKey + 1].fe == key[1].fe &&
+                keys[cacheIndexKey + 2].fe == key[2].fe &&
+                keys[cacheIndexKey + 3].fe == key[3].fe)
+            {
+                uint32_t cacheIndexValue = cacheIndex * 12;
+                value.resize(12);
+                value[0] = values[cacheIndexValue];
+                value[1] = values[cacheIndexValue + 1];
+                value[2] = values[cacheIndexValue + 2];
+                value[3] = values[cacheIndexValue + 3];
+                value[4] = values[cacheIndexValue + 4];
+                value[5] = values[cacheIndexValue + 5];
+                value[6] = values[cacheIndexValue + 6];
+                value[7] = values[cacheIndexValue + 7];
+                value[8] = values[cacheIndexValue + 8];
+                value[9] = values[cacheIndexValue + 9];
+                value[10] = values[cacheIndexValue + 10];
+                value[11] = values[cacheIndexValue + 11];
+                found=true;
+                if(distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSizeDiv2){
+                    reinsert = true;
+                }
+            }
         }
     }
-    return false;
+    return found;
 }

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -175,54 +175,6 @@ void DatabaseMTAssociativeCache::clear(){
     currentCacheIndex = 0;
 }
 
-bool DatabaseMTAssociativeCache::extractKeyValue_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value)
-{
-    bool found = false;    
-    //
-    // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
-    // for this reason this search is not optimized at all
-    //
-    if(auxBufferKeysValues.size() > 0){ 
-        found = extractKeyValueFromAuxBuffer_(key,value);
-    }
-    //
-    // Look at the circulant buffer
-    //
-    if(found == false){
-        for (int i = 0; i < 4; i++)
-        {
-            uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
-            if (hasExpired_(cacheIndexRaw)) continue;
-            
-            uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
-            uint32_t cacheIndexKey = cacheIndex * 4;
-            if (keys[cacheIndexKey + 0].fe == key[0].fe &&
-                keys[cacheIndexKey + 1].fe == key[1].fe &&
-                keys[cacheIndexKey + 2].fe == key[2].fe &&
-                keys[cacheIndexKey + 3].fe == key[3].fe)
-            {
-                isValidKey[cacheIndex]=false;
-                uint32_t cacheIndexValue = cacheIndex * 12;
-                value.resize(12);
-                value[0] = values[cacheIndexValue];
-                value[1] = values[cacheIndexValue + 1];
-                value[2] = values[cacheIndexValue + 2];
-                value[3] = values[cacheIndexValue + 3];
-                value[4] = values[cacheIndexValue + 4];
-                value[5] = values[cacheIndexValue + 5];
-                value[6] = values[cacheIndexValue + 6];
-                value[7] = values[cacheIndexValue + 7];
-                value[8] = values[cacheIndexValue + 8];
-                value[9] = values[cacheIndexValue + 9];
-                value[10] = values[cacheIndexValue + 10];
-                value[11] = values[cacheIndexValue + 11]; 
-                return true;  
-            }
-        }
-    }
-    return found;
-}
-
 bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
     //
     // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -207,7 +207,6 @@ bool DatabaseMTAssociativeCache::extractKeyValue_(const Goldilocks::Element (&ke
 }
 
 bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
-    bool found = false;    
     //
     // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
     // for this reason this search is not optimized at all
@@ -235,11 +234,11 @@ bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks:
                 value[11] = auxBufferKeysValues[i+16];
                 //erase the value
                 auxBufferKeysValues.erase(auxBufferKeysValues.begin() + i, auxBufferKeysValues.begin() + i + 17);   
-                found=true;
+                return true;
             }
         } 
     }
-    return found;
+    return false;
 }
 
 void DatabaseMTAssociativeCache::addKeyValue_(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update)
@@ -304,7 +303,7 @@ void DatabaseMTAssociativeCache::addKeyValue_(const Goldilocks::Element (&key)[4
     //
     // Add value
     //
-    isValidKey[cacheIndex] = true;
+    if(!isValidKey[cacheIndex]) isValidKey[cacheIndex] = true; //avoid modify if uneccessary (cache effects)
     keys[cacheIndexKey + 0].fe = key[0].fe;
     keys[cacheIndexKey + 1].fe = key[1].fe;
     keys[cacheIndexKey + 2].fe = key[2].fe;
@@ -465,7 +464,6 @@ void DatabaseMTAssociativeCache::forcedInsertion_(uint32_t (&usedRawCacheIndexes
 
 bool DatabaseMTAssociativeCache::findKey_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value, bool &reinsert)
 {
-    bool found = false;
     reinsert = false;
     //
     // look at the auxBufferKeysValues (chances that this buffer has any entry are almost negligible),
@@ -495,51 +493,48 @@ bool DatabaseMTAssociativeCache::findKey_(const Goldilocks::Element (&key)[4], v
                 value[9] = auxBufferKeysValues[i+14];
                 value[10] = auxBufferKeysValues[i+15];
                 value[11] = auxBufferKeysValues[i+16];
-                found=true;
                 if(distanceFromCurrentCacheIndex_((uint32_t)(auxBufferKeysValues[i].fe)) > cacheSizeDiv2){
                     reinsert = true;
                 }
-                break;
+                return true;
             }
         } 
     }
     //
     // Look at the circulant buffer
     //
-    if(!found){
-        for (int i = 0; i < 4; i++)
-        {
-            uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
-            if (hasExpired_(cacheIndexRaw)) continue;
-            
-            uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
-            uint32_t cacheIndexKey = cacheIndex * 4;
+    for (int i = 0; i < 4; i++)
+    {
+        uint32_t cacheIndexRaw = indexes[key[i].fe & indexesMask];
+        if (hasExpired_(cacheIndexRaw)) continue;
+        
+        uint32_t cacheIndex = cacheIndexRaw  & cacheMask;
+        uint32_t cacheIndexKey = cacheIndex * 4;
 
-            if (keys[cacheIndexKey + 0].fe == key[0].fe &&
-                keys[cacheIndexKey + 1].fe == key[1].fe &&
-                keys[cacheIndexKey + 2].fe == key[2].fe &&
-                keys[cacheIndexKey + 3].fe == key[3].fe)
-            {
-                uint32_t cacheIndexValue = cacheIndex * 12;
-                value.resize(12);
-                value[0] = values[cacheIndexValue];
-                value[1] = values[cacheIndexValue + 1];
-                value[2] = values[cacheIndexValue + 2];
-                value[3] = values[cacheIndexValue + 3];
-                value[4] = values[cacheIndexValue + 4];
-                value[5] = values[cacheIndexValue + 5];
-                value[6] = values[cacheIndexValue + 6];
-                value[7] = values[cacheIndexValue + 7];
-                value[8] = values[cacheIndexValue + 8];
-                value[9] = values[cacheIndexValue + 9];
-                value[10] = values[cacheIndexValue + 10];
-                value[11] = values[cacheIndexValue + 11];
-                found=true;
-                if(distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSizeDiv2){
-                    reinsert = true;
-                }
+        if (keys[cacheIndexKey + 0].fe == key[0].fe &&
+            keys[cacheIndexKey + 1].fe == key[1].fe &&
+            keys[cacheIndexKey + 2].fe == key[2].fe &&
+            keys[cacheIndexKey + 3].fe == key[3].fe)
+        {
+            uint32_t cacheIndexValue = cacheIndex * 12;
+            value.resize(12);
+            value[0] = values[cacheIndexValue];
+            value[1] = values[cacheIndexValue + 1];
+            value[2] = values[cacheIndexValue + 2];
+            value[3] = values[cacheIndexValue + 3];
+            value[4] = values[cacheIndexValue + 4];
+            value[5] = values[cacheIndexValue + 5];
+            value[6] = values[cacheIndexValue + 6];
+            value[7] = values[cacheIndexValue + 7];
+            value[8] = values[cacheIndexValue + 8];
+            value[9] = values[cacheIndexValue + 9];
+            value[10] = values[cacheIndexValue + 10];
+            value[11] = values[cacheIndexValue + 11];
+            if(distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSizeDiv2){
+                reinsert = true;
             }
+            return true;
         }
     }
-    return found;
+    return false;
 }

--- a/src/hashdb/database_associative_cache.cpp
+++ b/src/hashdb/database_associative_cache.cpp
@@ -231,6 +231,8 @@ bool DatabaseMTAssociativeCache::extractKeyValueFromAuxBuffer_(const Goldilocks:
     if(auxBufferKeysValues.size() > 0){ 
         if(auxBufferKeysValues.size() % 17!= 0) {
             zklog.error("DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() auxBufferKeysValues.size() % 17!= 0");
+            exitProcess();
+
         }
         for(size_t i=0; i<auxBufferKeysValues.size(); i+=17){
 
@@ -463,6 +465,8 @@ bool DatabaseMTAssociativeCache::findKey_(const Goldilocks::Element (&key)[4], v
     if(auxBufferKeysValues.size() > 0){ 
         if(auxBufferKeysValues.size() % 17!= 0) {
             zklog.error("DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() auxBufferKeysValues.size() % 17!= 0");
+            exitProcess();
+
         }
         for(size_t i=0; i<auxBufferKeysValues.size(); i+=17){
             

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -4,6 +4,7 @@
 #include "goldilocks_base_field.hpp"
 #include <nlohmann/json.hpp>
 #include <mutex>
+#include <shared_mutex>
 #include "zklog.hpp"
 #include "zkmax.hpp"
 
@@ -11,49 +12,126 @@ using namespace std;
 class DatabaseMTAssociativeCache
 {
     private:
-        recursive_mutex mlock;
-
-        int log2IndexesSize;
+        shared_mutex mlock;
+        
+        uint32_t log2IndexesSize;
         uint32_t indexesSize;
-        int log2CacheSize;
+        uint32_t log2CacheSize;
         uint32_t cacheSize;
+        uint32_t cacheSizeDiv2;
 
         uint32_t *indexes;
         Goldilocks::Element *keys;
+        bool *isValidKey;
         Goldilocks::Element *values;
-        uint32_t currentCacheIndex; 
+        uint32_t currentCacheIndex; //next index to be used acts as a clock for the cache
 
+#ifdef LOG_ASSOCIATIVE_CACHE
         uint64_t attempts;
         uint64_t hits;
+#endif
         string name;
 
-        uint64_t indexesMask;
-        uint64_t cacheMask;
+        uint32_t indexesMask;
+        uint32_t cacheMask;
 
+        vector<Goldilocks::Element> auxBufferKeysValues;
+        // The buffer uses 17 slots for each key-value pair:
+        // 1 for the raw cache index, 4 for the key, 12 for the value
 
     public:
 
         DatabaseMTAssociativeCache();
-        DatabaseMTAssociativeCache(int log2IndexesSize_, int log2CacheSize_, string name_);
+        DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_ = "associative_cache");
+        DatabaseMTAssociativeCache(uint64_t cacheBytes_, string name_ = "associative_cache");
         ~DatabaseMTAssociativeCache();
+        void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
+        void clear();
+        
+        inline void addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
+        inline bool findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
 
-        void postConstruct(int log2IndexesSize_, int log2CacheSize_, string name_);
-        void addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
-        bool findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
         inline bool enabled() const { return (log2IndexesSize > 0); };
         inline uint32_t getCacheSize()  const { return cacheSize; };
         inline uint32_t getIndexesSize() const { return indexesSize; };
-        inline void clear(){
-            if(enabled()){
-                postConstruct(log2IndexesSize, log2CacheSize, name);                
-            }
-        }
+        inline uint32_t getAuxBufferKeysValuesSize() const { return auxBufferKeysValues.size(); };
 
     private:
-        inline bool emptyCacheSlot(uint32_t cacheIndexRaw) const { 
-            return (currentCacheIndex >= cacheIndexRaw &&  currentCacheIndex - cacheIndexRaw > cacheSize) ||
-            (currentCacheIndex < cacheIndexRaw && UINT32_MAX - cacheIndexRaw + currentCacheIndex > cacheSize);
+        void addKeyValue_(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
+        bool findKey_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value, bool &reinsert);
+        bool extractKeyValue_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
+        bool extractKeyValueFromAuxBuffer_(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value);
+        
+         inline bool hasExpired_(uint32_t cacheIndexRaw) const { 
+            return  !isValidKey[cacheIndexRaw & cacheMask] || distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSize ;
          };
-        void forcedInsertion(uint32_t (&usedRawCacheIndexes)[10], int &iters);
+        inline uint32_t distanceFromCurrentCacheIndex_(uint32_t cacheIndexRaw) const {
+            //note: currentCacheIndex is the next index to be used (not used yet)
+            if(currentCacheIndex == cacheIndexRaw) return UINT32_MAX; //it should be UINT32_MAX + 1 but is out of range
+            return (currentCacheIndex > cacheIndexRaw) ? currentCacheIndex - cacheIndexRaw : UINT32_MAX - cacheIndexRaw + currentCacheIndex + 1;
+         };
+        void forcedInsertion_(uint32_t (&usedRawCacheIndexes)[20], uint32_t &iters, bool update);
+        inline void cleanExpiredAuxBufferKeysValues_();
+
 };
+
+void DatabaseMTAssociativeCache::addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update){
+    // This wrapper is used to avoid the necessity of using lock_guard within the addKeyValue_ function
+    unique_lock<shared_mutex> lock(mlock);
+    addKeyValue_(key, value, update);
+}
+bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], vector<Goldilocks::Element> &value){
+    bool reinsert=false;
+    bool found=false;
+    {
+        shared_lock<shared_mutex> lock(mlock);
+        found = findKey_(key, value, reinsert);
+    }
+    if(reinsert){
+        unique_lock<shared_mutex> lock(mlock);
+        vector<Goldilocks::Element> values_;
+
+        bool foundAgain = extractKeyValue_(key, values_);
+        // Retrieved the values again (values_) to prevent potential modifications 
+        // by another thread between the findKey_ and the addKeyValue_ operations
+        if(foundAgain) addKeyValue_(key, values_, false);
+    }
+
+#ifdef LOG_ASSOCIATIVE_CACHE
+    mlock.lock();
+    attempts++; 
+    if(found){
+        hits++;
+    }
+    mlock.unlock();
+    //
+    //  Statistics
+    //
+    if (attempts<<34 == 0)
+    {
+        zklog.info("DatabaseMTAssociativeCache::findKey() name=" + name + " indexesSize=" + to_string(indexesSize) + " cacheSize=" + to_string(cacheSize) + " attempts=" + to_string(attempts) + " hits=" + to_string(hits) + " hit ratio=" + to_string(double(hits) * 100.0 / double(zkmax(attempts, 1))) + "%");
+        if(auxBufferKeysValues.size()>0){
+            zklog.warning("DatabaseMTAssociativeCache using auxBufferKeysValues" + to_string(auxBufferKeysValues.size()));
+        }
+    }
+#endif
+
+    return found;
+}
+void DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() {
+    if(auxBufferKeysValues.size() == 0) return;
+    if(auxBufferKeysValues.size() % 17!= 0) {
+        zklog.error("DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() auxBufferKeysValues.size() % 17!= 0");
+        return;
+    }
+    auto it = auxBufferKeysValues.begin();
+    while (it != auxBufferKeysValues.end()) {
+        uint32_t cacheIndexRaw = static_cast<uint32_t>(it->fe);
+        if (hasExpired_(cacheIndexRaw)) {
+            it = auxBufferKeysValues.erase(it, it + 17);
+        } else {
+            std::advance(it, 17);
+        }
+    }
+}
 #endif

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -93,7 +93,6 @@ bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], ve
 if(reinsert){
         mlock.lock();
         vector<Goldilocks::Element> values_;
-
         bool foundAgain = extractKeyValue_(key, values_);
         // Retrieved the values again (values_) to prevent potential modifications 
         // by another thread between the findKey_ and the addKeyValue_ operations
@@ -132,7 +131,7 @@ void DatabaseMTAssociativeCache::cleanExpiredAuxBufferKeysValues_() {
     auto it = auxBufferKeysValues.begin();
     while (it != auxBufferKeysValues.end()) {
         uint32_t cacheIndexRaw = static_cast<uint32_t>(it->fe);
-        if (hasExpired_(cacheIndexRaw)) {
+        if (distanceFromCurrentCacheIndex_(cacheIndexRaw) > cacheSize) {
             it = auxBufferKeysValues.erase(it, it + 17);
         } else {
             std::advance(it, 17);

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -4,6 +4,8 @@
 #include "goldilocks_base_field.hpp"
 #include <shared_mutex>
 #include "zklog.hpp"
+#include "zkassert.hpp"
+
 
 using namespace std;
 class DatabaseMTAssociativeCache

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -45,7 +45,8 @@ class DatabaseMTAssociativeCache
         DatabaseMTAssociativeCache(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_ = "associative_cache");
         DatabaseMTAssociativeCache(uint64_t cacheBytes_, string name_ = "associative_cache");
         ~DatabaseMTAssociativeCache();
-        void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_);
+        void postConstruct(uint32_t log2IndexesSize_, uint32_t log2CacheSize_, string name_= "associative_cache");
+        void postConstruct(uint64_t cacheBytes_, string name_ = "associative_cache");
         void clear();
         
         inline void addKeyValue(const Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -91,13 +91,15 @@ bool DatabaseMTAssociativeCache::findKey(const Goldilocks::Element (&key)[4], ve
     mlock.unlock_shared();
 
 if(reinsert){
-        unique_lock<shared_mutex> lock(mlock);
+        mlock.lock();
         vector<Goldilocks::Element> values_;
 
         bool foundAgain = extractKeyValue_(key, values_);
         // Retrieved the values again (values_) to prevent potential modifications 
         // by another thread between the findKey_ and the addKeyValue_ operations
         if(foundAgain) addKeyValue_(key, values_, false);
+        mlock.unlock();
+
     }
 
 #ifdef LOG_ASSOCIATIVE_CACHE

--- a/src/hashdb/database_associative_cache.hpp
+++ b/src/hashdb/database_associative_cache.hpp
@@ -96,7 +96,8 @@ if(reinsert){
         bool foundAgain = extractKeyValue_(key, values_);
         // Retrieved the values again (values_) to prevent potential modifications 
         // by another thread between the findKey_ and the addKeyValue_ operations
-        if(foundAgain) addKeyValue_(key, values_, false);
+        // update = true of false is the same since it will not be found...
+        if(foundAgain) addKeyValue_(key, values_, true);
         mlock.unlock();
 
     }

--- a/src/hashdb/database_cache.cpp
+++ b/src/hashdb/database_cache.cpp
@@ -244,6 +244,93 @@ void DatabaseMTCache::updateRecord(DatabaseCacheRecord* record, const void * val
     *(vector<Goldilocks::Element>*)(record->value) = *(vector<Goldilocks::Element>*)(value);
 }
 
+uint32_t DatabaseMTCache::fillCache(){
+
+    vector<Goldilocks::Element> value0(12);
+    value0[0].fe = 0;
+    vector<Goldilocks::Element> value1(12);
+    value1[0].fe = 0;
+
+    Goldilocks::Element key[4];
+    for (uint64_t i=0; i<maxSize/256; i++)
+    {
+        key[0].fe = i;
+        key[1].fe = i+1;
+        key[2].fe = i+2;
+        key[3].fe = i+3;
+        
+        string keyString = fea2string(fr,key); 
+        add(keyString,value0, false);
+        //get a random value from 0 to i
+        uint64_t random = rand() % (i+1);
+        key[0].fe = random;
+        key[1].fe = random+1;
+        key[2].fe = random+2;
+        key[3].fe = random+3;
+        find(fea2string(fr, key), value1);
+        value0[0]= value0[0]+value1[0];
+    }
+    return 1;
+
+}
+
+uint32_t DatabaseMTCache::fillCacheCahotic(){
+
+    vector<Goldilocks::Element> value0(12);
+    value0[0].fe = 0;
+    vector<Goldilocks::Element> value1(12);
+    value1[0].fe = 0;
+
+    uint32_t ndist = 1<<20;
+    uint32_t mask = ndist-1;
+    char ** memory_distorsion = (char**) malloc(ndist*sizeof(char*));
+    for (uint32_t i=0; i<ndist; i++)
+    {
+        memory_distorsion[i] = NULL;
+    }
+    uint32_t count = 0;
+    
+    Goldilocks::Element key[4];
+    for (uint64_t i=0; i<maxSize/256; i++)
+    {
+        key[0].fe = i;
+        key[1].fe = i+1;
+        key[2].fe = i+2;
+        key[3].fe = i+3;
+        
+        string keyString = fea2string(fr,key); 
+        add(keyString,value0, false);
+        //get a random value from 0 to i
+        uint64_t random = rand() % (i+1);
+        key[0].fe = random;
+        key[1].fe = random+1;
+        key[2].fe = random+2;
+        key[3].fe = random+3;
+        find(fea2string(fr, key), value1);
+        value0[0]= value0[0]+value1[0];
+        if(memory_distorsion[i & mask] != NULL)
+        {
+            free(memory_distorsion[i & mask]);
+        }
+        memory_distorsion[i & mask] = (char*) malloc((1<<20)*sizeof(char));
+        if(i%2==0) memory_distorsion[i & mask][3728] = 'a';
+    }
+    for(uint32_t i=0; i<ndist; i++)
+    {
+        if(memory_distorsion[i] != NULL)
+        {
+            if(memory_distorsion[i][3728] == 'a')
+            {
+                count++;
+            }
+            free(memory_distorsion[i]);
+        }
+    }
+    free(memory_distorsion);
+    return count;
+
+}
+
 // DatabaseProgramCache class implementation
 
 DatabaseProgramCache::~DatabaseProgramCache()

--- a/src/hashdb/database_cache.hpp
+++ b/src/hashdb/database_cache.hpp
@@ -67,6 +67,9 @@ public:
     DatabaseCacheRecord* allocRecord(const string key, const void * value) override;
     void freeRecord(DatabaseCacheRecord* record) override;
     void updateRecord(DatabaseCacheRecord* record, const void * value) override;
+    
+    uint32_t fillCache(); //fuctin only for benchmarkin purposes
+    uint32_t fillCacheCahotic(); //fuctin only for benchmarkin purposes
 };
 
 class DatabaseProgramCache : public DatabaseCache

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,6 +495,7 @@ int main(int argc, char **argv)
     if (config.runDatabaseCacheTest)
     {
         DatabaseCacheTest();
+        //DatabaseCacheBenchmark();
     }
 
     // Test check tree

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -406,15 +406,16 @@ int main(int argc, char **argv)
     /* INIT DB CACHE */
     if(config.useAssociativeCache){
         Database::useAssociativeCache = true;
-        Database::dbMTACache.postConstruct(config.log2DbMTAssociativeCacheIndexesSize, config.log2DbMTAssociativeCacheSize, "MTACache");
+        //Database::dbMTACache.postConstruct(config.log2DbMTAssociativeCacheIndexesSize, config.log2DbMTAssociativeCacheSize, "MTACache");
+        Database::dbMTACache.postConstruct(uint64_t(config.dbProgramCacheSize)*uint64_t(1024)*uint64_t(1024), "MTCache");
     }
     else{
         Database::useAssociativeCache = false;
         Database::dbMTCache.setName("MTCache");
-        Database::dbMTCache.setMaxSize(config.dbMTCacheSize*1024*1024);
+        Database::dbMTCache.setMaxSize(config.dbMTCacheSize*uint64_t(1024)*uint64_t(1024));
     }
     Database::dbProgramCache.setName("ProgramCache");
-    Database::dbProgramCache.setMaxSize(config.dbProgramCacheSize*1024*1024);
+    Database::dbProgramCache.setMaxSize(config.dbProgramCacheSize*uint64_t(1024)*uint64_t(1024));
 
     if (config.databaseURL != "local") // remote DB
     {

--- a/test/hashdb/database_cache_test.cpp
+++ b/test/hashdb/database_cache_test.cpp
@@ -4,6 +4,7 @@
 #include "scalar.hpp"
 
 #define NUMBER_OF_DB_CACHE_ADDS 1000
+#define NUMBER_OF_DB_CACHE_BENCHS 20000000 
 
 uint64_t DatabaseCacheTest (void)
 {
@@ -51,5 +52,301 @@ uint64_t DatabaseCacheTest (void)
     Database::dbMTCache.clear();
 
     TimerStopAndLog(DATABASE_CACHE_TEST);
+
+    TimerStart(DATABASE_ASSOCIATIVE_CACHE_TEST);
+
+    DatabaseMTAssociativeCache cache1(20, 17, "cache1");
+    uint64_t NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS = cache1.getCacheSize();
+    //test addKeyValue addKeyValue(Goldilocks::Element (&key)[4], const vector<Goldilocks::Element> &value, bool update);
+
+    //generate a set of random keys
+    PoseidonGoldilocks poseidon_test;
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> InputValue;
+        for(int k=0; k<12; ++k){
+            InputValue.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(InputValue.data()[0]));
+        cache1.addKeyValue(key, InputValue, false);
+    }
+    //test findKey
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        value.clear();
+        bResult = cache1.findKey(key, value);
+        if (!bResult)
+        {
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+        if(bResult){
+            //check the value is correct
+            for(int k=0; k<12; ++k){
+                if(value[k].fe != fr.fromU64(i).fe){
+                    zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+                    numberOfFailed++;
+                }
+            }
+        }
+
+    }
+    // test update
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        // modify the value
+        for(int k=0; k<12; ++k){
+            value[k] = fr.fromU64(i+1);
+        }
+        cache1.addKeyValue(key, value, true);
+    }
+    //test findKey with updated values
+     for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        value.clear();
+        bResult = cache1.findKey(key, value);
+        //check the value is found
+        if (!bResult)
+        {
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+        //check the value is correct
+        for(int k=0; k<12; ++k){
+            if(value[k].fe != fr.fromU64(i+1).fe){
+                zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+                numberOfFailed++;
+            }
+        }
+
+    }
+    //test clear: clear the cache and check I do not find previous keys
+    cache1.clear();
+    for (uint64_t i=0; i<NUMBER_OF_DB_ASSOCIATIVE_CACHE_ADDS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        bResult = cache1.findKey(key, value);
+        //check the value is found
+        if (bResult)
+        {
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+    //collisions and auxBufferKeysValues
+    Goldilocks::Element key1[4];
+    Goldilocks::Element key2[4];
+    Goldilocks::Element key3[4];
+    key1[0] = fr.fromU64(0);
+    key1[1] = fr.fromU64(0);
+    key1[2] = fr.fromU64(0);
+    key1[3] = fr.fromU64(0);
+
+    key2[0] = fr.fromU64(uint64_t(1)<<50);
+    key2[1] = fr.fromU64(0);
+    key2[2] = fr.fromU64(0);
+    key2[3] = fr.fromU64(0);
+    
+    key3[0] = fr.fromU64(0);
+    key3[1] = fr.fromU64(uint64_t(1)<<44);
+    key3[2] = fr.fromU64(0);
+    key3[3] = fr.fromU64(0);
+    
+    // Key 0 and Key 1 have only one position availe in the indexes table, if I add both the buffer auxBufferKeysValues should be used
+    vector<Goldilocks::Element> value1(12);
+    vector<Goldilocks::Element> value2(12);
+    vector<Goldilocks::Element> value3(12);
+    for(int k=0; k<12; ++k){
+        value1[k] = fr.fromU64(1);
+        value2[k] = fr.fromU64(2);
+        value3[k] = fr.fromU64(3);
+    }
+    cache1.addKeyValue(key1, value1, false);
+    if(cache1.getAuxBufferKeysValuesSize()!=0){
+        zklog.error("DatabaseCacheTest() failed calling cache1.getAuxBufferKeysValuesSize()");
+        numberOfFailed++;
+    }
+    cache1.addKeyValue(key2, value2, false);
+    if(cache1.getAuxBufferKeysValuesSize()!=17){
+        zklog.error("DatabaseCacheTest() failed calling cache1.getAuxBufferKeysValuesSize()");
+        numberOfFailed++;
+    }
+    cache1.addKeyValue(key3, value3, false);
+    if(cache1.getAuxBufferKeysValuesSize()!=34){
+        zklog.error("DatabaseCacheTest() failed calling cache1.getAuxBufferKeysValuesSize()");
+        numberOfFailed++;
+    }
+    
+    //check the values are correct
+    vector<Goldilocks::Element> value1_;
+    bResult = cache1.findKey(key1, value1_);
+    if (!bResult)
+    {
+        zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+        numberOfFailed++;
+    }
+    for(int k=0; k<12; ++k){
+        if(value1_[k].fe != value1[k].fe){
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+    
+    vector<Goldilocks::Element> value2_;
+    bResult = cache1.findKey(key2, value2_);
+    if (!bResult)
+    {
+        zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+        numberOfFailed++;
+    }
+    for(int k=0; k<12; ++k){
+        if(value2_[k].fe != value2[k].fe){
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+    
+    vector<Goldilocks::Element> value3_;
+    bResult = cache1.findKey(key3, value3_);
+    if (!bResult)
+    {
+        zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+        numberOfFailed++;
+    }
+    for(int k=0; k<12; ++k){
+        if(value3_[k].fe != value3[k].fe){
+            zklog.error("DatabaseCacheTest() failed calling cache1.findKey() of key=" + keyString);
+            numberOfFailed++;
+        }
+    }
+
+    //check that after doing a round to the cache the elements are not anymore into de auxBufferKeysValues
+    for (uint64_t i=0; i<2*cache1.getCacheSize(); i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> value;
+        for(int k=0; k<12; ++k){
+            value.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(value.data()[0]));
+        // modify the value
+        for(int k=0; k<12; ++k){
+            value[k] = fr.fromU64(i+1);
+        }
+        cache1.addKeyValue(key, value, true);
+        if(cache1.getAuxBufferKeysValuesSize()==0 && i<cache1.getCacheSize()-2){
+            zklog.error("DatabaseCacheTest() auxBufferKeysValues should not be cleaned" + to_string(cache1.getAuxBufferKeysValuesSize()));
+            numberOfFailed++;
+        }
+    }
+    
+    if(cache1.getAuxBufferKeysValuesSize()!=0){
+        zklog.error("DatabaseCacheTest() failed the cleaning of auxBufferKeysValues"+ to_string(cache1.getAuxBufferKeysValuesSize()));
+        numberOfFailed++;
+    }
+    TimerStopAndLog(DATABASE_ASSOCIATIVE_CACHE_TEST);
+    assert(numberOfFailed == 0);
     return numberOfFailed;
+}
+
+uint64_t DatabaseCacheBenchmark (void){
+
+    // Generate 10M of hashes
+    PoseidonGoldilocks poseidon_test;
+    Goldilocks::Element* keys= new Goldilocks::Element[NUMBER_OF_DB_CACHE_BENCHS*4];
+    vector<string> keyStrings(NUMBER_OF_DB_CACHE_BENCHS);
+    for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_BENCHS; i++)
+    {
+        Goldilocks::Element key[4];
+        vector<Goldilocks::Element> InputValue;
+        for(int k=0; k<12; ++k){
+            InputValue.push_back(fr.fromU64(i));
+        } 
+        poseidon_test.hash(key,(Goldilocks::Element(&)[12])(InputValue.data()[0]));
+        keys[i*4] = key[0];
+        keys[i*4+1] = key[1];
+        keys[i*4+2] = key[2];
+        keys[i*4+3] = key[3];
+        keyStrings[i] = fea2string(fr, (Goldilocks::Element(&)[4]) key);
+    }
+    vector<Goldilocks::Element> value(12);
+
+    DatabaseMTCache cache_map;
+    cache_map.setMaxSize(uint64_t(8)*uint64_t(1024)*uint64_t(1024)*uint64_t(1024));
+    DatabaseMTAssociativeCache cache_ass(28, 25, "associativeCache");
+    
+    TimerStart(DATABASE_CACHE_BENCHMARK);
+    int count_hits = 0;
+    for(int k=0; k<4; k++){
+        for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_BENCHS; i++)
+        {
+            string keyString = fea2string(fr, (Goldilocks::Element(&)[4]) keys[4*i]); 
+            cache_map.add(keyString,value, false);
+            //cache_map.add(keyStrings[i],value, false);
+
+        }
+    }
+    for(int k=0; k<4; k++){
+        for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_BENCHS; i++)
+        {
+            string keyString = fea2string(fr, (Goldilocks::Element(&)[4]) keys[4*i]); 
+            /*if(cache_map.find(keyStrings[i], value)){
+                ++count_hits;
+            }*/
+            if(cache_map.find(keyString, value)){
+                ++count_hits;
+            }
+
+        }
+    }
+    //std::cout<<"Hits with cache map:"<<count_hits<<::endl;
+    count_hits = 0;
+    TimerStopAndLog(DATABASE_CACHE_BENCHMARK);
+    cache_map.clear();
+    TimerStart(DATABASE_CACHE_ASSOCIATIVE_BENCHMARK);
+    for(int k=0; k<4; k++){
+        for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_BENCHS; i++)
+        {
+            cache_ass.addKeyValue((Goldilocks::Element(&)[4]) keys[4*i], value, false);
+
+        }
+    }
+    for(int k=0; k<4; k++){
+        for (uint64_t i=0; i<NUMBER_OF_DB_CACHE_BENCHS; i++)
+        {
+            if(cache_ass.findKey((Goldilocks::Element(&)[4]) keys[4*i], value)){
+                ++count_hits;
+            }
+
+        }
+    }
+    //std::cout<<"Hits with cache associative:"<<count_hits<<::endl;
+    TimerStopAndLog(DATABASE_CACHE_ASSOCIATIVE_BENCHMARK);
+    delete[] keys;
+    return 1;
+
 }

--- a/test/hashdb/database_cache_test.hpp
+++ b/test/hashdb/database_cache_test.hpp
@@ -4,5 +4,6 @@
 #include <cstdint>
 
 uint64_t DatabaseCacheTest (void);
+uint64_t DatabaseCacheBenchmark (void);
 
 #endif


### PR DESCRIPTION
This PR extends the capability of previous implementation of associative cache.

1) Considers the edge case in which a key can not be included into the cache . For each key, 4 possible locations into the associative cache are considered, if these 4 slots are already in use, an iterative process is started in which we try to reallocate the "collisioning" keys. Chances to not find a slot during this iterative process are almost negligible however, for the sake of safety we have added a buffer to temporally allocate entries which could not be included with the "normal" process, this buffer is used only temporarily and is cleaned automatically.

2) A new approach is implemented to keep entries in the cache after reading/updating operations. If the cache is of size N, when a cache entry is read or updated and more than N/2 inserts have occurred after its original insert, the entry is re-inserted into the cache so its extended its availability into the cache.

Unity test have been added to test the functioning of the extension buffer and re-inserts
