### PR TITLE
Fix Typo in main_generator.cpp and starkRecursiveF.cpp

### DIFF
--- a/src/main_generator/main_generator.cpp
+++ b/src/main_generator/main_generator.cpp
@@ -326,7 +326,7 @@ string generate(const json &rom, uint64_t forkID, string forkNamespace, const st
     code += "    bool bProcessBatch = (proverRequest.type == prt_processBatch);\n";
     code += "    bool bUnsignedTransaction = (proverRequest.input.from != \"\") && (proverRequest.input.from != \"0x\");\n\n";
     
-    code += "    // Unsigned transactions (from!=empty) are intended to be used to \"estimage gas\" (or \"call\")\n";
+    code += "    // Unsigned transactions (from!=empty) are intended to be used to \"estimate gas\" (or \"call\")\n";
     code += "    // In prover mode, we cannot accept unsigned transactions, since the proof would not meet the PIL constrains\n";
     code += "    if (bUnsignedTransaction && !bProcessBatch)\n";
     code += "    {\n";

--- a/src/main_generator/main_generator.cpp
+++ b/src/main_generator/main_generator.cpp
@@ -3518,7 +3518,7 @@ code += "    #endif\n";
             code += "        {\n";
             code += "            proverRequest.result = ZKR_SM_MAIN_HASHP_SIZE_MISMATCH;\n";
             code += "            zkPC=" + to_string(zkPC) +";\n";
-            code += "            mainExecutor.logError(ctx, \"HashP 2 diferent read sizes in the same position addr=\" + to_string(addr) + \" pos=\" + to_string(pos));\n";
+            code += "            mainExecutor.logError(ctx, \"HashP 2 different read sizes in the same position addr=\" + to_string(addr) + \" pos=\" + to_string(pos));\n";
             code += "            mainExecutor.pHashDB->cancelBatch(proverRequest.uuid);\n";
             code += "            return;\n";
             code += "        }\n";

--- a/src/starkpil/starkRecursiveF/starkRecursiveF.cpp
+++ b/src/starkpil/starkRecursiveF/starkRecursiveF.cpp
@@ -147,14 +147,14 @@ void StarkRecursiveF::genProof(FRIProofC12 &proof, Goldilocks::Element publicInp
     StarkRecursiveFSteps recurisveFsteps;
     StarkRecursiveFSteps *steps = &recurisveFsteps;
     // Initialize vars
-    uint64_t numCommited = starkInfo.nCm1;
+    uint64_t numCommitted = starkInfo.nCm1;
     TranscriptBN128 transcript;
     Polinomial evals(N, FIELD_EXTENSION);
     Polinomial xDivXSubXi(NExtended, FIELD_EXTENSION);
     Polinomial xDivXSubWXi(NExtended, FIELD_EXTENSION);
     Polinomial challenges(NUM_CHALLENGES, FIELD_EXTENSION);
 
-    CommitPolsStarks cmPols(pAddress, starkInfo.mapDeg.section[eSection::cm1_n], numCommited);
+    CommitPolsStarks cmPols(pAddress, starkInfo.mapDeg.section[eSection::cm1_n], numCommitted);
 
     RawFr::Element rootC;
     RawFr::Element root0;


### PR DESCRIPTION
- Corrected "estimage" to "estimate" in `main_generator.cpp`.
- Fixed "diferent" to "different" in error logging in `main_generator.cpp`.
- Fixed spelling of "recurisve" to "recursive" in `starkRecursiveF.cpp`.
- Corrected "numCommited" to "numCommitted" in `starkRecursiveF.cpp`.