### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/prover_e2e.yml
+++ b/.github/workflows/prover_e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, linux, X64, hc, hm]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
     - uses: actions/setup-node@v2

--- a/.github/workflows/push-docker-tagged.yaml
+++ b/.github/workflows/push-docker-tagged.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Submodule init
         run: |

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set variables
         id: setvars


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected