### PR TITLE
ci: bump setup-node to v4

### DIFF
--- a/.github/workflows/prover_e2e.yml
+++ b/.github/workflows/prover_e2e.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: 'true'
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
     - name: Install snarkjs


### PR DESCRIPTION
Maintenance update: switch all jobs to setup-node@v4 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v4.0.0 release](https://github.com/actions/setup-node/releases/tag/v4.0.0).