### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/prover_e2e.yml
+++ b/.github/workflows/prover_e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, linux, X64, hc, hm]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         submodules: 'true'
     - uses: actions/setup-node@v2


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0